### PR TITLE
Move OverloadedStrings from language pragmas to cabal file

### DIFF
--- a/Database/Persist/ProjectM36.hs
+++ b/Database/Persist/ProjectM36.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes, TypeFamilies, GeneralizedNewtypeDeriving, OverloadedStrings, FlexibleInstances, FlexibleContexts #-}
+{-# LANGUAGE RankNTypes, TypeFamilies, GeneralizedNewtypeDeriving, FlexibleInstances, FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Database.Persist.ProjectM36 where
 import Database.Persist hiding (Assign, Update)

--- a/ProjectM36/Atom.hs
+++ b/ProjectM36/Atom.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Atom where
 import ProjectM36.Base
 import ProjectM36.Error

--- a/ProjectM36/AtomFunction.hs
+++ b/ProjectM36/AtomFunction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.AtomFunction where
 import ProjectM36.Base
 import ProjectM36.Error

--- a/ProjectM36/AtomFunctions/Basic.hs
+++ b/ProjectM36/AtomFunctions/Basic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 --atom functions on primitive atom values plus the basic atom functions
 module ProjectM36.AtomFunctions.Basic where
 import ProjectM36.Base
@@ -13,4 +12,4 @@ basicAtomFunctions = HS.unions [primitiveAtomFunctions,
                                 dayAtomFunctions,
                                 eitherAtomFunctions,
                                 maybeAtomFunctions]
-       
+

--- a/ProjectM36/AtomFunctions/Primitive.hs
+++ b/ProjectM36/AtomFunctions/Primitive.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.AtomFunctions.Primitive where
 import ProjectM36.Atom
 import ProjectM36.Base

--- a/ProjectM36/AtomType.hs
+++ b/ProjectM36/AtomType.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.AtomType where
 import ProjectM36.Base
 import ProjectM36.ConcreteTypeRep

--- a/ProjectM36/Client.hs
+++ b/ProjectM36/Client.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric #-}
 module ProjectM36.Client
        (ConnectionInfo(..),
        Connection(..),

--- a/ProjectM36/DataTypes/Basic.hs
+++ b/ProjectM36/DataTypes/Basic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- wraps up primitives plus other basic data types
 module ProjectM36.DataTypes.Basic where
 import ProjectM36.DataTypes.Primitive
@@ -13,9 +12,3 @@ basicTypeConstructorMapping = (primitiveTypeConstructorMapping ++
                                eitherTypeConstructorMapping ++ 
                                dayTypeConstructorMapping)
 
-                 
-                
-
-
-                
-                

--- a/ProjectM36/DataTypes/Day.hs
+++ b/ProjectM36/DataTypes/Day.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DataTypes.Day where
 import ProjectM36.Base
 import ProjectM36.DataTypes.Primitive

--- a/ProjectM36/DataTypes/Either.hs
+++ b/ProjectM36/DataTypes/Either.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DataTypes.Either where
 import ProjectM36.Base
 import ProjectM36.DataTypes.Primitive

--- a/ProjectM36/DataTypes/Interval.hs
+++ b/ProjectM36/DataTypes/Interval.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, StandaloneDeriving, OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module ProjectM36.DataTypes.Interval where
 import Data.Interval

--- a/ProjectM36/DataTypes/Maybe.hs
+++ b/ProjectM36/DataTypes/Maybe.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DataTypes.Maybe where
 import ProjectM36.Base
 import ProjectM36.DataTypes.Primitive

--- a/ProjectM36/DataTypes/Primitive.hs
+++ b/ProjectM36/DataTypes/Primitive.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DataTypes.Primitive where
 import ProjectM36.Base
 import Data.Proxy

--- a/ProjectM36/DatabaseContext.hs
+++ b/ProjectM36/DatabaseContext.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DatabaseContext where
 import ProjectM36.Base
 import qualified Data.Map as M

--- a/ProjectM36/DateExamples.hs
+++ b/ProjectM36/DateExamples.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.DateExamples where
 import ProjectM36.Base
 import ProjectM36.Atom

--- a/ProjectM36/Key.hs
+++ b/ProjectM36/Key.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Key where
 import ProjectM36.Base
 import ProjectM36.Relation

--- a/ProjectM36/Relation.hs
+++ b/ProjectM36/Relation.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,ExistentialQuantification,OverloadedStrings #-}
+{-# LANGUAGE GADTs,ExistentialQuantification #-}
 module ProjectM36.Relation where
 import qualified Data.Set as S
 import qualified Data.HashSet as HS

--- a/ProjectM36/Relation/Parse/CSV.hs
+++ b/ProjectM36/Relation/Parse/CSV.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Relation.Parse.CSV where
 --parse Relations from CSV
 import Data.Csv.Parser

--- a/ProjectM36/Relation/Show/CSV.hs
+++ b/ProjectM36/Relation/Show/CSV.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module ProjectM36.Relation.Show.CSV where
 import ProjectM36.Base

--- a/ProjectM36/Relation/Show/Gnuplot.hs
+++ b/ProjectM36/Relation/Show/Gnuplot.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Relation.Show.Gnuplot where
 import ProjectM36.Base
 import ProjectM36.Relation

--- a/ProjectM36/Relation/Show/HTML.hs
+++ b/ProjectM36/Relation/Show/HTML.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Relation.Show.HTML where
 import ProjectM36.Base
 import ProjectM36.Relation

--- a/ProjectM36/Relation/Show/Term.hs
+++ b/ProjectM36/Relation/Show/Term.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 --writes Relation to a String suitable for terminal output
 module ProjectM36.Relation.Show.Term where
 import ProjectM36.Base

--- a/ProjectM36/RelationalExpression.hs
+++ b/ProjectM36/RelationalExpression.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.RelationalExpression where
 import ProjectM36.Relation
 import ProjectM36.Tuple

--- a/ProjectM36/Sessions.hs
+++ b/ProjectM36/Sessions.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Sessions where
 import Control.Concurrent.STM
 import qualified STMContainers.Map as STMMap

--- a/ProjectM36/Transaction.hs
+++ b/ProjectM36/Transaction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.Transaction where
 import ProjectM36.Base
 import qualified Data.Set as S

--- a/ProjectM36/TransactionGraph.hs
+++ b/ProjectM36/TransactionGraph.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, DeriveAnyClass, DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric #-}
 module ProjectM36.TransactionGraph where
 import ProjectM36.Base
 import ProjectM36.Error

--- a/ProjectM36/TransactionGraph/Persist.hs
+++ b/ProjectM36/TransactionGraph/Persist.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.TransactionGraph.Persist where
 import ProjectM36.Error
 import ProjectM36.TransactionGraph

--- a/ProjectM36/TransactionGraph/Show.hs
+++ b/ProjectM36/TransactionGraph/Show.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ProjectM36.TransactionGraph.Show where
 import ProjectM36.Base
 import ProjectM36.TransactionGraph

--- a/TutorialD/Interpreter.hs
+++ b/TutorialD/Interpreter.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
 module TutorialD.Interpreter where
 import TutorialD.Interpreter.Base
 import TutorialD.Interpreter.RODatabaseContextOperator

--- a/TutorialD/Interpreter/Base.hs
+++ b/TutorialD/Interpreter/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module TutorialD.Interpreter.Base where
 import Text.Parsec
 import Text.Parsec.String

--- a/TutorialD/Interpreter/DatabaseContextExpr.hs
+++ b/TutorialD/Interpreter/DatabaseContextExpr.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module TutorialD.Interpreter.DatabaseContextExpr where
 import Text.Parsec
 import Text.Parsec.String

--- a/TutorialD/Interpreter/InformationOperator.hs
+++ b/TutorialD/Interpreter/InformationOperator.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module TutorialD.Interpreter.InformationOperator where
 import Data.Text
 import Text.Parsec

--- a/TutorialD/Interpreter/RODatabaseContextOperator.hs
+++ b/TutorialD/Interpreter/RODatabaseContextOperator.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
 module TutorialD.Interpreter.RODatabaseContextOperator where
 import ProjectM36.Base
 import qualified ProjectM36.Client as C

--- a/TutorialD/tutd.hs
+++ b/TutorialD/tutd.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE CPP #-}
 import TutorialD.Interpreter
 import ProjectM36.Base
 import ProjectM36.Client

--- a/docs/on_null.markdown
+++ b/docs/on_null.markdown
@@ -377,7 +377,7 @@ Algebraic data types in SQL are effectively impossible.
 Any Haskell data type can be turned into a value (called an "atom") in Project:M36. The following example illustrates:
 
 ```haskell
-{-# LANGUAGE OverloadedStrings,DeriveAnyClass,DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass,DeriveGeneric #-}
 module Hospital where
 
 import ProjectM36.Client

--- a/examples/Hospital.hs
+++ b/examples/Hospital.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings,DeriveAnyClass,DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass,DeriveGeneric #-}
 module Hospital where
 
 import ProjectM36.Client

--- a/examples/SimpleClient.hs
+++ b/examples/SimpleClient.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import ProjectM36.Client
 import ProjectM36.TupleSet
 import ProjectM36.Atom

--- a/examples/out_of_the_tarpit.hs
+++ b/examples/out_of_the_tarpit.hs
@@ -1,5 +1,5 @@
 -- the Out-of-the-Tarpit example in Haskell and Project:M36
-{-# LANGUAGE OverloadedStrings, DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass #-}
 import ProjectM36.Client
 import qualified Data.Text as T
 import ProjectM36.Atom

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -117,6 +117,7 @@ Library
       C-sources: ProjectM36/DirectoryFsync.c
       Build-Depends: unix
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
 
 Executable tutd
     Build-Depends: base >=4.8 && <4.9, 
@@ -216,6 +217,7 @@ Executable tutd
     CPP-Options: -DPROJECTM36_VERSION="v0.1"
     GHC-Options: -Wall 
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     if os(windows)
       Build-Depends: Win32 >= 2.3 && < 2.4
       Other-Modules: ProjectM36.Win32Handle
@@ -264,6 +266,7 @@ Executable project-m36-server
     GHC-Options: -Wall -threaded -rtsopts
     GHC-Prof-Options: -fprof-auto -rtsopts -threaded -Wall
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     Other-Modules: ProjectM36.Atom,
                    ProjectM36.AtomFunction,
                    ProjectM36.AtomFunctions.Basic,
@@ -314,6 +317,7 @@ Executable project-m36-server
 
 Executable bigrel
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, optparse-applicative, stm-containers, list-t
     Other-Modules: ProjectM36.Base,
                    ProjectM36.Relation
@@ -362,6 +366,7 @@ Executable bigrel
 
 Test-Suite test-tutoriald
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/TutorialD/Interpreter.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers, list-t
@@ -378,6 +383,7 @@ Test-Suite test-tutoriald
 
 Test-Suite test-relation
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/Relation/Basic.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -387,6 +393,7 @@ Test-Suite test-relation
 
 Test-Suite test-static-optimizer
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/Relation/StaticOptimizer.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -396,6 +403,7 @@ Test-Suite test-static-optimizer
 
 Test-Suite test-transactiongraph-persist
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/TransactionGraph/Persist.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -412,6 +420,7 @@ Test-Suite test-transactiongraph-persist
 
 Test-Suite test-relation-import-csv
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/Relation/Import/CSV.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -421,6 +430,7 @@ Test-Suite test-relation-import-csv
 
 Test-Suite test-tutoriald-import-tutoriald
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/TutorialD/Interpreter/Import/TutorialD.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -430,6 +440,7 @@ Test-Suite test-tutoriald-import-tutoriald
 
 Test-Suite test-relation-export-csv
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/Relation/Export/CSV.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, stm-containers
@@ -439,6 +450,7 @@ Test-Suite test-relation-export-csv
 
 Test-Suite test-persistent-driver
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/persistent-driver/test.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, template-haskell, transformers, aeson, persistent-template, conduit, persistent >= 2.2 && < 2.3, either, path-pieces, http-api-data, stm-containers, list-t
@@ -456,6 +468,7 @@ Test-Suite test-persistent-driver
 
 Test-Suite test-transactiongraph-merge
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/TransactionGraph/Merge.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, unix, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, template-haskell, transformers, aeson, persistent-template, conduit, persistent, either, path-pieces, http-api-data, stm-containers, list-t
@@ -466,6 +479,7 @@ Test-Suite test-transactiongraph-merge
 
 benchmark bench
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: benchmark/Relation.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, criterion, stm-containers
@@ -474,6 +488,7 @@ benchmark bench
 
 Test-Suite test-server
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/Server/Main.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t
@@ -491,6 +506,7 @@ Test-Suite test-server
 
 Executable Example-SimpleClient
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t
     Main-Is: examples/SimpleClient.hs
     GHC-Options: -Wall
@@ -543,6 +559,7 @@ Executable Example-SimpleClient
 
 Executable Example-PersistClient
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t, persistent, aeson, path-pieces, either, conduit, http-api-data, template-haskell, persistent-template
     Main-Is: examples/PersistClient.hs
     GHC-Options: -Wall
@@ -593,6 +610,7 @@ Executable Example-PersistClient
     
 Test-Suite test-scripts
     Default-Language: Haskell2010
+    Default-Extensions: OverloadedStrings
     type: exitcode-stdio-1.0
     main-is: test/scripts.hs
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, network-transport-tcp, distributed-process, distributed-process-extras, distributed-process-client-server, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, parsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t

--- a/test/Relation/Basic.hs
+++ b/test/Relation/Basic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import Test.HUnit
 import ProjectM36.Base
 import ProjectM36.Relation

--- a/test/Relation/Export/CSV.hs
+++ b/test/Relation/Export/CSV.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import Test.HUnit
 import ProjectM36.Base
 import System.Exit

--- a/test/Relation/Import/CSV.hs
+++ b/test/Relation/Import/CSV.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import Test.HUnit
 import ProjectM36.Base
 import ProjectM36.Relation.Parse.CSV

--- a/test/Relation/StaticOptimizer.hs
+++ b/test/Relation/StaticOptimizer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import ProjectM36.Base
 import ProjectM36.Relation
 import ProjectM36.DateExamples

--- a/test/Server/Main.hs
+++ b/test/Server/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-
 test client/server interaction
 -}

--- a/test/TransactionGraph/Merge.hs
+++ b/test/TransactionGraph/Merge.hs
@@ -1,5 +1,4 @@
 -- tests for transaction merging
-{-# LANGUAGE OverloadedStrings #-}
 import Test.HUnit
 import ProjectM36.Base
 import ProjectM36.Relation

--- a/test/TransactionGraph/Persist.hs
+++ b/test/TransactionGraph/Persist.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings,LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
 import Test.HUnit
 import ProjectM36.Base
 import ProjectM36.Persist (DiskSync(NoDiskSync))

--- a/test/TutorialD/Interpreter.hs
+++ b/test/TutorialD/Interpreter.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import TutorialD.Interpreter.DatabaseContextExpr
 import TutorialD.Interpreter
 import TutorialD.Interpreter.Base

--- a/test/TutorialD/Interpreter/Import/TutorialD.hs
+++ b/test/TutorialD/Interpreter/Import/TutorialD.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 import Test.HUnit
 import ProjectM36.Base
 import ProjectM36.Atom

--- a/test/persistent-driver/test.hs
+++ b/test/persistent-driver/test.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 import Test.HUnit
 import Database.Persist.ProjectM36


### PR DESCRIPTION
This makes the code easier for newcomers as all files string literals are treated uniformly regardless of the language pragmas being used.

Besides we get rid of several lines since this was already the desired default behaviour, and as I can see in #8 the idea is to completely eliminate the `String` type.