### PR TITLE
Removed CPP restriction on Control.Monad

### DIFF
--- a/src/bin/TutorialD/Interpreter/Base.hs
+++ b/src/bin/TutorialD/Interpreter/Base.hs
@@ -15,9 +15,7 @@ import System.IO
 import ProjectM36.Relation.Show.Term
 import GHC.Generics
 import Data.Monoid
-#if __GLASGOW_HASKELL__ >= 800
 import Control.Monad (void)
-#endif
 import qualified Data.UUID as U
 import ProjectM36.Relation
 import Control.Monad.Random


### PR DESCRIPTION
The `void` operator does exist in older versions of
Control.Monad. Removing this constraint allows stack based builds to
occur successfully under lts-6.27.