### PR TITLE
Export DatabaseContextIOExpr from Client

### DIFF
--- a/src/lib/ProjectM36/Client.hs
+++ b/src/lib/ProjectM36/Client.hs
@@ -38,6 +38,7 @@ module ProjectM36.Client
        RelationalExpr,
        RelationalExprBase(..),
        DatabaseContextExpr(..),
+       DatabaseContextIOExpr(..),
        Attribute(..),
        attributesFromList,
        createNodeId,


### PR DESCRIPTION
If you intentionally left this out of the export list, then just close this PR. However, I thought it was likely an oversight since `Client` does export `executeDatabaseContextIOExpr` which uses this type.