### PR TITLE
fix haddock of ProjectM36.Client.Simple

### DIFF
--- a/src/lib/ProjectM36/Client/Simple.hs
+++ b/src/lib/ProjectM36/Client/Simple.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | A simplified client interface for Project:M36 database access.
 module ProjectM36.Client.Simple (
   simpleConnectProjectM36,
   simpleConnectProjectM36At,
@@ -27,7 +29,6 @@ module ProjectM36.Client.Simple (
   C.DatabaseContextExpr(..),
   C.RelationalExprBase(..)
   ) where
--- | A simplified client interface for Project:M36 database access.
 
 import Control.Exception.Base
 import Control.Monad ((<=<))


### PR DESCRIPTION
The module description haddock comment was in the wrong place, causing haddock to fail. I suppose this is also true of the version 0.2 released on hackage, and that's why there are no docs there yet? Would it be worth cutting another release just to fix the docs?