### PR TITLE
make notification old/new expression distinction explicit

### DIFF
--- a/src/bin/ProjectM36/Server/WebSocket/project-m36.js
+++ b/src/bin/ProjectM36/Server/WebSocket/project-m36.js
@@ -10,7 +10,7 @@
 * @param {promptCallback} promptCallback - A function called whenever prompt information such as the current schema name and current branch name (if any).
 * @param {closeCallback} closeCallback - A function called once the connection is closed.
 */
-var ProjectM36Connection = function (protocol, host, port, path, dbname, openCallback, errorCallback, statusCallback, promptCallback, closeCallback) {
+var ProjectM36Connection = function (protocol, host, port, path, dbname, openCallback, errorCallback, statusCallback, promptCallback, notificationCallback, closeCallback) {
     this.protocol = protocol;
     this.host = host;
     this.port = port;
@@ -44,6 +44,7 @@ var ProjectM36Connection = function (protocol, host, port, path, dbname, openCal
     };
     this.statuscallback = statusCallback;
     this.promptcallback = promptCallback;
+    this.notificationcallback = notificationCallback;
     this.socket = socket;
 }
 
@@ -77,6 +78,7 @@ ProjectM36Connection.prototype.handleResponse = function(message)
     var acknowledged = message["acknowledged"];
     var error = message["displayerror"];
     var prompt = message["promptInfo"];
+    var notification = message["notificationname"]
 
     if(relation)
     {
@@ -100,6 +102,12 @@ ProjectM36Connection.prototype.handleResponse = function(message)
     if(prompt)
     {
 	this.promptcallback(prompt["headname"], prompt["schemaname"]);
+    }
+
+    if(notification)
+    {
+	var evaldnotif = message.evaldnotification;
+	this.notificationcallback(message.notificationname, evaldnotif);
     }
 }
 

--- a/src/bin/ProjectM36/Server/WebSocket/websocket-client.js
+++ b/src/bin/ProjectM36/Server/WebSocket/websocket-client.js
@@ -49,6 +49,48 @@ function promptUpdate(headName, schemaName)
     document.getElementById("promptinfo").textContent = "Current Branch: (" + headName + ") Schema: (" + schemaName + ")";
 }
 
+function relationErrorAsString(errObj)
+{
+    return errObj.tag + " " + errObj.contents;
+}
+
+function notificationUpdate(notificationName, evaldNotif)
+{
+    //generate two tables for display
+    var notifDiv = document.createElement('div');
+    var oldInfo = document.createElement('div');
+    oldInfo.textContent = "Pre-change info: ";
+    var newInfo = document.createElement('div');
+    newInfo.textContent = "Post-change info: ";
+    var status = "Notification received: " + notificationName;
+
+    if(evaldNotif.reportOldRelation.Left)
+    {
+	var errOld = evaldNotif.reportOldRelation.Left;
+	oldInfo.textContent += relationErrorAsString(errOld);
+    }
+    else if(evaldNotif.reportOldRelation.Right)
+    {
+	oldInfo.appendChild(conn.generateRelation(evaldNotif.reportOldRelation.Right));
+    }
+
+    if(evaldNotif.reportNewRelation.Left)
+    {
+	var errNew = evaldNotif.reportNewRelation.Left;
+	newInfo.textContent += relationErrorAsString(errNew);
+    }
+    else if(evaldNotif.reportNewRelation.Right)
+    {
+	newInfo.appendChild(conn.generateRelation(evaldNotif.reportNewRelation.Right));
+    }
+
+    notifDiv.appendChild(oldInfo);
+    notifDiv.appendChild(document.createElement('br'));
+    notifDiv.appendChild(newInfo);
+    appendResult(status,notifDiv);
+    mungeEmptyRows();
+}
+
 var conn;
 
 function connectOrDisconnect(form)
@@ -82,6 +124,7 @@ function connectOrDisconnect(form)
 					       connectionError,
 					       updateStatus,
 					       promptUpdate,
+					       notificationUpdate,
 					       connectionClosed);
 	toggleConnectionFields(form, false, "Connecting...");
     }

--- a/src/bin/TutorialD/Interpreter.hs
+++ b/src/bin/TutorialD/Interpreter.hs
@@ -123,7 +123,7 @@ evalTutorialDInteractive sessionId conn safe interactive expr = case expr of
         cancel <- runInputT settings $ do
           let promptDiscardChanges = do
                 isatty <- haveTerminalUI
-                if isatty && interactive then do
+                if isatty && interactive && execOp /= Commit && execOp /= Rollback then do
                   mYesOrNo <- getInputLine "The current transaction has uncommitted changes. If you continue, the changes will be lost. Continue? (Y/n): "
                   case mYesOrNo of
                     Nothing -> promptDiscardChanges
@@ -222,12 +222,13 @@ data InterpreterConfig = LocalInterpreterConfig PersistenceStrategy HeadName (Ma
                          RemoteInterpreterConfig C.NodeId C.DatabaseName HeadName (Maybe TutorialDExec)
 
 outputNotificationCallback :: C.NotificationCallback
-outputNotificationCallback notName evaldNot = hPutStrLn stderr $ "Notification received " ++ show notName ++ ":\n" ++ show (reportExpr (C.notification evaldNot)) ++ "\n" ++ prettyEvaluatedNotification evaldNot
+outputNotificationCallback notName evaldNot = hPutStrLn stderr $ "Notification received " ++ show notName ++ ":\n" ++ "\n" ++ prettyEvaluatedNotification evaldNot
 
 prettyEvaluatedNotification :: C.EvaluatedNotification -> String
-prettyEvaluatedNotification eNotif = case C.reportRelation eNotif of
-  Left err -> show err
-  Right reportRel -> T.unpack (showRelation reportRel)
+prettyEvaluatedNotification eNotif = let eRelShow eRel = case eRel of
+                                           Left err -> show err
+                                           Right reportRel -> T.unpack (showRelation reportRel) in
+  eRelShow (C.reportOldRelation eNotif) <> "\n" <> eRelShow (C.reportNewRelation eNotif)
 
 reprLoop :: InterpreterConfig -> C.SessionId -> C.Connection -> IO ()
 reprLoop config sessionId conn = do

--- a/src/bin/TutorialD/Interpreter/DatabaseContextExpr.hs
+++ b/src/bin/TutorialD/Interpreter/DatabaseContextExpr.hs
@@ -153,8 +153,9 @@ addNotificationP = do
   reserved "notify"
   notName <- identifier
   triggerExpr <- relExprP 
-  resultExpr <- relExprP
-  pure $ AddNotification notName triggerExpr resultExpr
+  resultOldExpr <- relExprP
+  resultNewExpr <- relExprP
+  pure $ AddNotification notName triggerExpr resultOldExpr resultNewExpr
   
 removeNotificationP :: Parser DatabaseContextExpr  
 removeNotificationP = do

--- a/src/lib/ProjectM36/Base.hs
+++ b/src/lib/ProjectM36/Base.hs
@@ -227,7 +227,8 @@ type Notifications = M.Map NotificationName Notification
 -- | When the changeExpr returns a different result in the database context, then the reportExpr is triggered and sent asynchronously to all clients.
 data Notification = Notification {
   changeExpr :: RelationalExpr,
-  reportExpr :: RelationalExpr
+  reportOldExpr :: RelationalExpr, --run the expression in the pre-change context
+  reportNewExpr :: RelationalExpr --run the expression in the post-change context
   }
   deriving (Show, Eq, Binary, Generic, NFData)
 
@@ -317,7 +318,7 @@ data DatabaseContextExpr =
   AddInclusionDependency IncDepName InclusionDependency |
   RemoveInclusionDependency IncDepName |
   
-  AddNotification NotificationName RelationalExpr RelationalExpr |
+  AddNotification NotificationName RelationalExpr RelationalExpr RelationalExpr |
   RemoveNotification NotificationName |
 
   AddTypeConstructor TypeConstructorDef [DataConstructorDef] |

--- a/src/lib/ProjectM36/Notifications.hs
+++ b/src/lib/ProjectM36/Notifications.hs
@@ -9,8 +9,8 @@ import Data.Either (isRight)
 notificationChanges :: Notifications -> DatabaseContext -> DatabaseContext -> Notifications
 notificationChanges nots context1 context2 = M.filter notificationFilter nots
   where
-    notificationFilter (Notification chExpr _) = let oldChangeEval = evalChangeExpr chExpr (RelationalExprStateElems context1)
-                                                     newChangeEval = evalChangeExpr chExpr (RelationalExprStateElems context2) in
+    notificationFilter (Notification chExpr _ _) = let oldChangeEval = evalChangeExpr chExpr (RelationalExprStateElems context1)
+                                                       newChangeEval = evalChangeExpr chExpr (RelationalExprStateElems context2) in
                                                  oldChangeEval /= newChangeEval && isRight oldChangeEval
     evalChangeExpr chExpr = runReader (evalRelationalExpr chExpr)
 

--- a/src/lib/ProjectM36/RelationalExpression.hs
+++ b/src/lib/ProjectM36/RelationalExpression.hs
@@ -366,7 +366,7 @@ evalDatabaseContextExpr (RemoveInclusionDependency depName) = do
     return Nothing
     
 -- | Add a notification which will send the resultExpr when triggerExpr changes between commits.
-evalDatabaseContextExpr (AddNotification notName triggerExpr resultExpr) = do
+evalDatabaseContextExpr (AddNotification notName triggerExpr resultOldExpr resultNewExpr) = do
   currentContext <- getStateContext
   let nots = notifications currentContext
   if M.member notName nots then
@@ -374,7 +374,8 @@ evalDatabaseContextExpr (AddNotification notName triggerExpr resultExpr) = do
     else do
       let newNotifications = M.insert notName newNotification nots
           newNotification = Notification { changeExpr = triggerExpr,
-                                           reportExpr = resultExpr }
+                                           reportOldExpr = resultOldExpr, 
+                                           reportNewExpr = resultNewExpr}
       putStateContext $ currentContext { notifications = newNotifications }
       return Nothing
   

--- a/src/lib/ProjectM36/StaticOptimizer.hs
+++ b/src/lib/ProjectM36/StaticOptimizer.hs
@@ -148,16 +148,13 @@ applyStaticDatabaseOptimization dep@(AddInclusionDependency _ _) = return $ Righ
 
 applyStaticDatabaseOptimization (RemoveInclusionDependency name) = return $ Right (RemoveInclusionDependency name)
 
-applyStaticDatabaseOptimization (AddNotification name triggerExpr resultExpr) = do
+applyStaticDatabaseOptimization (AddNotification name triggerExpr resultOldExpr resultNewExpr) = do
   context <- getStateContext
   let eTriggerExprOpt = runReader (applyStaticRelationalOptimization triggerExpr) (RelationalExprStateElems context)
   case eTriggerExprOpt of
          Left err -> pure $ Left err
-         Right triggerExprOpt -> do
-           let eResultExprOpt = runReader (applyStaticRelationalOptimization resultExpr) (RelationalExprStateElems context)
-           case eResultExprOpt of
-                  Left err -> pure $ Left err
-                  Right resultExprOpt -> pure (Right (AddNotification name triggerExprOpt resultExprOpt))
+         Right triggerExprOpt -> --it doesn't make sense to optimize queries when we don't have their proper contexts
+           pure (Right (AddNotification name triggerExprOpt resultOldExpr resultNewExpr))
 
 applyStaticDatabaseOptimization notif@(RemoveNotification _) = pure (Right notif)
 

--- a/test/Server/Main.hs
+++ b/test/Server/Main.hs
@@ -188,7 +188,7 @@ testNotification :: MVar () -> SessionId -> Connection -> Test
 testNotification mvar sess conn = TestCase $ do
   let relvarx = RelationVariable "x" ()
   executeDatabaseContextExpr sess conn (Assign "x" (ExistingRelation relationTrue)) >>= eitherFail
-  executeDatabaseContextExpr sess conn (AddNotification "test notification" relvarx relvarx) >>= eitherFail
+  executeDatabaseContextExpr sess conn (AddNotification "test notification" relvarx relvarx relvarx) >>= eitherFail
   commit sess conn >>= eitherFail
   executeDatabaseContextExpr sess conn (Assign "x" (ExistingRelation relationFalse)) >>= eitherFail
   commit sess conn >>= eitherFail

--- a/test/TutorialD/Interpreter.hs
+++ b/test/TutorialD/Interpreter.hs
@@ -270,7 +270,7 @@ testNotification = TestCase $ do
       relvarx = RelationVariable "x" ()
   (sess, conn) <- dateExamplesConnection (notifCallback notifmvar)
   executeDatabaseContextExpr sess conn (Assign "x" (ExistingRelation relationTrue)) >>= eitherFail
-  executeDatabaseContextExpr sess conn (AddNotification "test notification" relvarx relvarx) >>= eitherFail
+  executeDatabaseContextExpr sess conn (AddNotification "test notification" relvarx relvarx relvarx) >>= eitherFail
   commit sess conn >>= eitherFail
   executeDatabaseContextExpr sess conn (Assign "x" (ExistingRelation relationFalse)) >>= eitherFail
   commit sess conn >>= eitherFail


### PR DESCRIPTION
This patch allows notifications to carry two relational expressions for evaluation: one to be evaluated in the pre-change context and one to be evaluated in the post-change context. The expressions need not be identical. I used `true` as a placeholder for a no-op, but that could be improved.