### PR TITLE
Blog web example

### DIFF
--- a/examples/blog.hs
+++ b/examples/blog.hs
@@ -2,8 +2,11 @@
 {-# LANGUAGE DeriveAnyClass, DeriveGeneric, OverloadedStrings #-}
 
 import ProjectM36.Client
+import ProjectM36.Base
 import ProjectM36.Relation
 import ProjectM36.Tupleable
+import ProjectM36.Atom (relationForAtom)
+import ProjectM36.Tuple (atomForAttributeName)
 
 import Data.Either
 import GHC.Generics
@@ -13,10 +16,22 @@ import Data.Time.Clock
 import Data.Time.Calendar
 import Control.DeepSeq
 import Data.Proxy
+import Data.Monoid
+import Data.List
+import Control.Monad (when)
+
+import Web.Scotty as S
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+import Text.Blaze.Html.Renderer.Text
+import Control.Monad.IO.Class (liftIO)
+import Network.HTTP.Types.Status
+import Data.Time.Format
 
 --define your data types
 data Blog = Blog {
   title :: T.Text,
+  entry :: T.Text,
   stamp :: UTCTime,
   category :: Category --note that this type is an algebraic data type
   }
@@ -64,7 +79,10 @@ main = do
 
   createSchema sessionId conn  
   insertSampleData sessionId conn
-  executeSampleQueries sessionId conn
+  --executeSampleQueries sessionId conn
+  scotty 3000 $ do
+    S.get "/" (listBlogs sessionId conn)
+    S.get "/blog/:blogid" (showBlogEntry sessionId conn)
   
 --define the schema with the new Category atom (data) type, blog relvar, a comment relvar, and a foreign key relationship between them
 createSchema :: SessionId -> Connection -> IO ()  
@@ -79,16 +97,22 @@ createSchema sessionId conn = do
 --create some sample values and insert them into the database's relation variables
 insertSampleData :: SessionId -> Connection -> IO ()
 insertSampleData sessionId conn = do
-  let blogs = [Blog { title = "Eat More Tofu",
+  let blogs = [Blog { title = "Haskell Lenses",
+                      entry = "I wear Haskell rose-colored lenses.",
                       stamp = UTCTime (fromGregorian 2017 5 8) (secondsToDiffTime 1000),
                       category = Food },
-               Blog { title = "Cat Falls Off Table",
+               Blog { title = "Haskell Monad Analogy",
+                      entry = "Monads are like burritos going through intestines.",
                       stamp = UTCTime (fromGregorian 2017 6 10) (secondsToDiffTime 2000),
                       category = Cats }
                ]
-      comments = [Comment { blogTitle = "Cat Falls Off Table",
+      comments = [Comment { blogTitle = "Haskell Lenses",
                             commentTime = UTCTime (fromGregorian 2017 7 8) (secondsToDiffTime 3000),
-                            contents = "more cats please" }]
+                            contents = "You suck!" },
+                  Comment {blogTitle = "Haskell Lenses",
+                           commentTime = UTCTime (fromGregorian 2017 7 9) (secondsToDiffTime 2000),
+                           contents = "I find your ideas intriguing and would like to subscribe to your newsletter."}
+                 ]
   insertBlogsExpr <- handleError $ toInsertExpr blogs "blog"               
   handleIOError $ executeDatabaseContextExpr sessionId conn insertBlogsExpr
   
@@ -96,9 +120,75 @@ insertSampleData sessionId conn = do
   handleIOError $ executeDatabaseContextExpr sessionId conn insertCommentsExpr
   
 --issue a query and marshal the data back to the original data value  
+{-  
 executeSampleQueries :: SessionId -> Connection -> IO ()  
 executeSampleQueries sessionId conn = do
   commentsRelation <- handleIOError $ executeRelationalExpr sessionId conn (RelationVariable "comment" ())
   
   comments <- toList commentsRelation >>= mapM (handleError . fromTuple) :: IO [Comment]
   print comments
+-}
+
+handleWebError :: Either RelationalError a -> ActionM a 
+handleWebError (Left err) = render500 (H.toHtml (show err)) >> pure (error "bad")
+handleWebError (Right v) = pure v
+
+listBlogs :: SessionId -> Connection -> ActionM ()
+listBlogs sessionId conn = do
+  eRel <- liftIO $ executeRelationalExpr sessionId conn (RelationVariable "blog" ())
+  case eRel of
+    Left err -> render500 (H.toHtml (show err))
+    Right blogRel -> do
+      blogs <- liftIO (toList blogRel) >>= mapM (handleWebError . fromTuple) :: ActionM [Blog]
+      html . renderHtml $ do
+        H.h1 "Blog Posts"
+        mapM_ (\blog -> H.a H.! A.href (H.toValue $ "/blog/" <> title blog) $ H.h2 (H.toHtml (title blog))) blogs
+
+render500 :: H.Html -> ActionM ()
+render500 msg = do 
+  html . renderHtml $ do
+    H.h1 "Internal Server Error"  
+    H.p msg
+  status internalServerError500
+  
+showBlogEntry :: SessionId -> Connection -> ActionM ()
+showBlogEntry sessionId conn = do
+  blogid <- param "blogid"
+  --query the database to return the blog entry with a relation-valued attribute of the associated comments
+  let blogRestrictionExpr = AttributeEqualityPredicate "title" (NakedAtomExpr (TextAtom blogid))
+      extendExpr = AttributeExtendTupleExpr "comments" (RelationAtomExpr commentsRestriction)
+      commentsRestriction = Restrict
+                           (AttributeEqualityPredicate "blogTitle" (AttributeAtomExpr "title"))
+                           (RelationVariable "comment" ())
+  eRel <- liftIO $ executeRelationalExpr sessionId conn (Extend extendExpr 
+                                                         (Restrict 
+                                                          blogRestrictionExpr 
+                                                          (RelationVariable "blog" ())))
+  let render = html . renderHtml
+      formatStamp = formatTime defaultTimeLocale (iso8601DateFormat (Just "%H:%M:%S"))
+  case eRel of 
+    Left err -> render500 (H.toHtml (show err))
+    --handle successful query execution
+    Right rel -> case singletonTuple rel of
+      Nothing -> do --no results for this blog id
+        render (H.h1 "No such blog post")
+        status status404
+      Just blogTuple -> case fromTuple blogTuple of --just one blog post found- it's a match!
+        Left err -> render500 (H.toHtml (show err))
+        Right blog -> do
+          --extract comments for the blog
+          commentsAtom <- handleWebError (atomForAttributeName "comments" blogTuple)
+          commentsRel <- handleWebError (relationForAtom commentsAtom)
+          comments <- liftIO (toList commentsRel) >>= mapM (handleWebError . fromTuple) :: ActionM [Comment]
+          let commentsSorted = sortBy (\c1 c2 -> commentTime c1 `compare` commentTime c2) comments
+          render $ do
+            H.h1 (H.toHtml (title blog))
+            H.p (H.toHtml ("Posted at " <> formatStamp (stamp blog)))
+            H.p (H.toHtml (entry blog))
+            H.hr
+            H.h3 "Comments"
+            mapM_ (\comment -> do
+                    H.p (H.toHtml ("Commented at " <> formatStamp (commentTime comment)))
+                    H.p (H.toHtml (contents comment))) commentsSorted
+            when (length comments == 0) (H.p "No comments.")
+      

--- a/examples/blog.hs
+++ b/examples/blog.hs
@@ -205,13 +205,13 @@ addComment sessionId conn = do
   blogid <- param "blogid"
   commentText <- param "contents"
   now <- liftIO getCurrentTime
-  let commentAttrs = toAttributes (Proxy :: Proxy Comment)
-  case mkRelationFromList commentAttrs [[TextAtom blogid, 
-                                         DateTimeAtom now, 
-                                         TextAtom commentText]] of
+  
+  case toInsertExpr [Comment {blogTitle = blogid,
+                              commentTime = now,
+                              contents = commentText }] "comment" of
     Left err -> handleWebError (Left err)
-    Right newCommentRel -> do
-      eRet <- liftIO (withTransaction sessionId conn (executeDatabaseContextExpr sessionId conn (Insert "comment" (ExistingRelation newCommentRel))) (commit sessionId conn))
+    Right insertExpr -> do      
+      eRet <- liftIO (withTransaction sessionId conn (executeDatabaseContextExpr sessionId conn insertExpr) (commit sessionId conn))
       case eRet of
         Left err -> handleWebError (Left err)
         Right _ ->

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -410,7 +410,7 @@ Executable Example-OutOfTheTarpit
 Executable Example-Blog
     Default-Language: Haskell2010
     Default-Extensions: OverloadedStrings
-    Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, megaparsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t, aeson, path-pieces, either, conduit, http-api-data, template-haskell, ghc, ghc-paths, project-m36
+    Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, megaparsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t, aeson, path-pieces, either, conduit, http-api-data, template-haskell, ghc, ghc-paths, project-m36, scotty, blaze-html, http-types
     Main-Is: examples/blog.hs
     GHC-Options: -Wall
 


### PR DESCRIPTION
The blog example has been augmented with a scotty-based web interface as a demonstration of how Haskell data types can be easily marshalled between the database and back.

In this case, we have two data types: `Blog` and `Comment` where blogs are in a one-to-many relationship with comments.

Are there things here I could simplify to make it more accessible to newcomers?