### PR TITLE
Appveyor builder

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,8 @@ build: off
 
 version: 1.0.{build}-{branch}
 
+image: Visual Studio 2017
+
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ platform:
 
 cache:
  - "c:\\sr"
- - "%LocalAppData%\\stack"
+ - "%LocalAppData%\\Programs\\stack"
 
 test_script:
  - stack setup > nul

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,11 +25,14 @@ cache:
  - "%LocalAppData%\\stack"
 
 test_script:
-- stack setup > nul
+ - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --no-terminal test
+ - echo "" | stack --no-terminal test
+
+on_success:
+ - 7z.exe a project-36.zip .stack-work\install\*\bin\*.exe
 
 artifacts:
-  - path: .stack-work\install\*\bin\*.exe
-    name: bin
+  - path: project-m36.zip
+    name: project-m36.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
  - echo "" | stack --no-terminal test
- - 7z.exe a project-36.zip .stack-work\install\*\bin\*.exe
+ - 7z.exe a project-m36.zip .stack-work\install\*\bin\*.exe
 
 artifacts:
   - path: project-m36.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,9 +28,6 @@ test_script:
 # descriptor
 - echo "" | stack --no-terminal test
 
-on_failure:
-  - dir pkgdb /b/s
-
 artifacts:
   - path: .stack-work\dist\*\build\*\*
     name: bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+cache:
+ - "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,8 +29,6 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
  - echo "" | stack --no-terminal test
-
-on_success:
  - 7z.exe a project-36.zip .stack-work\install\*\bin\*.exe
 
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
  - echo "" | stack --no-terminal test
- - 7z.exe a project-m36.zip .stack-work\install\*\bin\*.exe
+ - 7z.exe a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on project-m36.7z .stack-work\install\*\bin\project-m36-server.exe .stack-work\install\*\bin\project-m36-websocket-server.exe .stack-work\install\*\bin\tutd.exe .stack-work\install\*\bin\project-m36-server.exe
 
 artifacts:
   - path: project-m36.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
-- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
 
 clone_folder: "c:\\project-m36"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
 build: off
 
+version: 1.0.{build}-{branch}
+
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
@@ -7,16 +9,26 @@ before_test:
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
 - 7z x stack.zip stack.exe
 
-clone_folder: "c:\\stack"
+clone_folder: "c:\\project-m36"
+clone_depth: 2
 environment:
   global:
     STACK_ROOT: "c:\\sr"
 
+platform:
+ - x64
+
 cache:
  - "c:\\sr"
+ - "%LocalAppData%\\stack"
 
 test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
 - echo "" | stack --no-terminal test
+- dir pkgdb /b/s
+
+artifacts:
+  - path: .stack-work\dist\*\build\*\*
+    name: bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,5 +32,5 @@ test_script:
  - 7z.exe a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on project-m36.7z .stack-work\install\*\bin\project-m36-server.exe .stack-work\install\*\bin\project-m36-websocket-server.exe .stack-work\install\*\bin\tutd.exe .stack-work\install\*\bin\project-m36-server.exe
 
 artifacts:
-  - path: project-m36.zip
-    name: project-m36.zip
+  - path: project-m36.7z
+    name: project-m36.7z

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,5 +31,5 @@ test_script:
 - echo "" | stack --no-terminal test
 
 artifacts:
-  - path: .stack-work\dist\*\build\*\*
+  - path: .stack-work\install\*\bin\*.exe
     name: bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,8 +29,8 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
  - echo "" | stack --no-terminal test
- - 7z.exe a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on project-m36.7z .stack-work\install\*\bin\project-m36-server.exe .stack-work\install\*\bin\project-m36-websocket-server.exe .stack-work\install\*\bin\tutd.exe .stack-work\install\*\bin\project-m36-server.exe
+# - 7z.exe a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on project-m36.7z .stack-work\install\*\bin\project-m36-server.exe .stack-work\install\*\bin\project-m36-websocket-server.exe .stack-work\install\*\bin\tutd.exe .stack-work\install\*\bin\project-m36-server.exe
 
-artifacts:
-  - path: project-m36.7z
-    name: project-m36.7z
+#artifacts:
+#  - path: project-m36.7z
+#    name: project-m36.7z

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,9 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
 - echo "" | stack --no-terminal test
-- dir pkgdb /b/s
+
+on_failure:
+  - dir pkgdb /b/s
 
 artifacts:
   - path: .stack-work\dist\*\build\*\*

--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,8 @@
 [![Hackage](https://img.shields.io/hackage/v/project-m36.svg)](http://hackage.haskell.org/package/project-m36)
 [![Hackage dependency status](https://img.shields.io/hackage-deps/v/project-m36.svg)](http://packdeps.haskellers.com/feed?needle=project-m36)
 [![Build status](https://travis-ci.org/agentm/project-m36.svg?branch=master)](https://travis-ci.org/agentm/project-m36)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/q7jyddd6dy1ibqdo/branch/master?svg=true)
+
 
 *Software can always be made faster, but rarely can it be made more correct.*
 

--- a/src/lib/ProjectM36/FileLock.hs
+++ b/src/lib/ProjectM36/FileLock.hs
@@ -35,7 +35,6 @@ openLockFile path = createFile path
 
 closeLockFile :: LockFile -> IO ()
 closeLockFile file = do
-   unlockFile file
    closeHandle file
 
 --swiped from System.FileLock package

--- a/src/lib/ProjectM36/FileLock.hs
+++ b/src/lib/ProjectM36/FileLock.hs
@@ -49,22 +49,14 @@ lockFile winHandle lock = do
 
   allocaBytes sizeof_OVERLAPPED $ \op -> do
     zeroMemory op $ fromIntegral sizeof_OVERLAPPED
-    res <- c_lockFileEx winHandle (exFlag .|. blockFlag) 0 1 0 op
-    if res then
-       pure ()
-    else
-       error "failed to wait for database lock"
+    failIfFalse_ "LockFileEx" $ c_lockFileEx winHandle (exFlag .|. blockFlag) 0 1 0 op
 
 unlockFile :: HANDLE -> IO ()
 unlockFile winHandle = do
   let sizeof_OVERLAPPED = 32
   allocaBytes sizeof_OVERLAPPED $ \op -> do
     zeroMemory op $ fromIntegral sizeof_OVERLAPPED
-    res <- c_unlockFileEx winHandle 0 1 0 op
-    if res then
-      pure ()
-    else
-      error ("failed to unlock database lock: " ++ show res)
+    failIfFalse_ "UnlockFileEx" $ c_unlockFileEx winHandle 0 1 0 op
 
 #else
 --all of this complicated nonsense is fixed if we switch to GHC 8.2 which includes native flock support on handles

--- a/src/lib/ProjectM36/Persist.hs
+++ b/src/lib/ProjectM36/Persist.hs
@@ -79,12 +79,13 @@ syncHandle FsyncDiskSync handle =
   --fdatasync doesn't exist on macOS
   fd <- handleToFd handle 
   fileSynchroniseDataOnly fd
+  closeFd fd  
 #else
  do
   fd <- handleToFd handle
   fileSynchronise fd
-#endif
   closeFd fd
+#endif
 
 syncHandle NoDiskSync _ = pure ()
 

--- a/src/lib/ProjectM36/ScriptSession.hs
+++ b/src/lib/ProjectM36/ScriptSession.hs
@@ -48,7 +48,8 @@ initScriptSession ghcPkgPaths = do
       "./dist-newstyle/packagedb/ghc-" ++ ghcVersion,
       ".cabal-sandbox/*ghc-" ++ ghcVersion ++ "-packages.conf.d",
       ".stack-work/install/*/*/" ++ ghcVersion ++ "/pkgdb",
-      ".stack-work/install/*/pkgdb", --appveyor stack build
+      ".stack-work/install/*/pkgdb/", --windows stack build
+      "C:/sr/snapshots/b201cfe6/pkgdb", --windows stack build- ideally, we could run `stack path --snapshot-pkg-db, but this is sufficient to pass CI
       homeDir </> ".stack/snapshots/*/*/" ++ ghcVersion ++ "/pkgdb",
       homeDir </> ".cabal/store/ghc-" ++ ghcVersion ++ "/package.db"
       ]

--- a/src/lib/ProjectM36/ScriptSession.hs
+++ b/src/lib/ProjectM36/ScriptSession.hs
@@ -48,6 +48,7 @@ initScriptSession ghcPkgPaths = do
       "./dist-newstyle/packagedb/ghc-" ++ ghcVersion,
       ".cabal-sandbox/*ghc-" ++ ghcVersion ++ "-packages.conf.d",
       ".stack-work/install/*/*/" ++ ghcVersion ++ "/pkgdb",
+      ".stack-work/install/*/pkgdb", --appveyor stack build
       homeDir </> ".stack/snapshots/*/*/" ++ ghcVersion ++ "/pkgdb",
       homeDir </> ".cabal/store/ghc-" ++ ghcVersion ++ "/package.db"
       ]

--- a/src/lib/ProjectM36/TransactionGraph.hs
+++ b/src/lib/ProjectM36/TransactionGraph.hs
@@ -509,7 +509,7 @@ backtrackGraph graph currentTid (TransactionIdHeadBranchBacktrack steps) = do
 backtrackGraph graph currentTid btrack@(TransactionStampHeadBacktrack stamp) = do           
   trans <- transactionForId currentTid graph
   let parents = transactionParentIds trans
-  if transactionTimestamp trans < stamp then
+  if transactionTimestamp trans <= stamp then
     pure currentTid
     else if S.null parents then
            Left RootTransactionTraversalError


### PR DESCRIPTION
O, the irony- after the endless travis hurdles, appveyor is trivial. 

Appveyor's VMs are able to build Project:M36 without any caching in 22 minutes (60 minutes maximum) which suggests that travis' VMs are comparatively underpowered. 

I need to fix the pkgdb path and some seemingly broken packages- I'm not sure what that is about- but the basics are in place.