### PR TITLE
Fix primitiveATypeName lookup

### DIFF
--- a/src/lib/ProjectM36/Atomable.hs
+++ b/src/lib/ProjectM36/Atomable.hs
@@ -229,7 +229,7 @@ instance (Atomable a) => AtomableG (K1 c a) where
     where
       tCons = PrimitiveTypeConstructor primitiveATypeName primitiveAType
       primitiveAType = toAtomType (Proxy :: Proxy a)
-      primitiveATypeName = fromMaybe (error ("primitive type missing: " ++ show primitiveAType)) (foldr (\(PrimitiveTypeConstructorDef name typ, _) _ -> if typ == primitiveAType then Just name else Nothing) Nothing primitiveTypeConstructorMapping)
+      primitiveATypeName = fromMaybe (error ("primitive type missing: " ++ show primitiveAType)) (foldr (\(PrimitiveTypeConstructorDef name typ, _) acc -> if typ == primitiveAType then Just name else acc) Nothing primitiveTypeConstructorMapping)
         
 instance AtomableG U1 where
   toAtomG = undefined


### PR DESCRIPTION
Running the blog example triggered the following exception when using CrashSafePersistence and trying to submit a comment from the web interface:
```UnhandledExceptionError "primitive type missing: TextAtomType\nCallStack (from HasCallStack):\n error, called at ./src/lib/ProjectM36/Atomable.hs:232:39 in project-m36-0.3-AaOlZo5ZXxJ9qLXdxcn1Yt:ProjectM36.Atomable"```
This PR fixes that.