### PR TITLE
Close file descriptor in syncDirectory

### DIFF
--- a/cbits/DirectoryFsync.c
+++ b/cbits/DirectoryFsync.c
@@ -29,6 +29,7 @@ int cDirectoryFsync(char *path)
 
   if(!S_ISDIR(fdstat.st_mode))
     {
+      close(fd);
       return ENOTDIR;
     }
   
@@ -43,6 +44,7 @@ int cDirectoryFsync(char *path)
     {
       return errno;
     }
+  close(fd);
   return 0;
 }
 #endif


### PR DESCRIPTION
When using CrashSafePersistence each transaction would leak 2 file descriptors, i.e:
```
mydb/heads
mydb/e580ab4e-b4cf-433f-a819-d6d00e2e773c
```