### PR TITLE
add with macro with multiple views

### DIFF
--- a/src/bin/TutorialD/Interpreter/RelationalExpr.hs
+++ b/src/bin/TutorialD/Interpreter/RelationalExpr.hs
@@ -130,7 +130,7 @@ relOperators = [
   ]
 
 relExprP :: RelationalMarkerExpr a => Parser (RelationalExprBase a)
-relExprP = makeExprParser relTerm relOperators
+relExprP = try withMacroExprP <|> makeExprParser relTerm relOperators
 
 relVarP :: RelationalMarkerExpr a => Parser (RelationalExprBase a)
 relVarP = RelationVariable <$> identifier <*> parseMarkerP
@@ -237,3 +237,18 @@ boolAtomP = do
   
 relationAtomExprP :: RelationalMarkerExpr a => Parser (AtomExprBase a)
 relationAtomExprP = RelationAtomExpr <$> makeRelationP
+
+withMacroExprP :: RelationalMarkerExpr a => Parser (RelationalExprBase a)
+withMacroExprP = do
+  reservedOp "WITH"
+  views <- parens (sepBy createViewP comma) 
+  expr <-relExprP
+  pure $ With views expr 
+
+createViewP :: RelationalMarkerExpr a => Parser (RelVarName, RelationalExprBase a)
+createViewP = do 
+  name <- identifier
+  reservedOp "AS"
+  expr <- relExprP
+  pure $ (name, expr)
+ 

--- a/src/lib/ProjectM36/Base.hs
+++ b/src/lib/ProjectM36/Base.hs
@@ -208,8 +208,10 @@ data RelationalExprBase a =
   --- | Returns the true relation iff 
   Equals (RelationalExprBase a) (RelationalExprBase a) |
   NotEquals (RelationalExprBase a) (RelationalExprBase a) |
-  Extend (ExtendTupleExprBase a) (RelationalExprBase a)
+  Extend (ExtendTupleExprBase a) (RelationalExprBase a) |
   --Summarize :: AtomExpr -> AttributeName -> RelationalExpr -> RelationalExpr -> RelationalExpr -- a special case of Extend
+  --Evaluate relationalExpr with scoped views
+  With [(RelVarName,RelationalExprBase a)] (RelationalExprBase a)
   deriving (Show, Eq, Generic, NFData)
            
 instance Binary RelationalExpr

--- a/src/lib/ProjectM36/StaticOptimizer.hs
+++ b/src/lib/ProjectM36/StaticOptimizer.hs
@@ -134,6 +134,8 @@ applyStaticRelationalOptimization e@(NotEquals _ _) = pure $ Right e
   
 applyStaticRelationalOptimization e@(Extend _ _) = pure $ Right e  
 
+applyStaticRelationalOptimization e@(With _ _) = pure $ Right e  
+
 applyStaticDatabaseOptimization :: DatabaseContextExpr -> DatabaseState (Either RelationalError DatabaseContextExpr)
 applyStaticDatabaseOptimization x@NoOperation = pure $ Right x
 applyStaticDatabaseOptimization x@(Define _ _) = pure $ Right x
@@ -378,6 +380,7 @@ applyStaticRestrictionCollapse expr =
     MakeStaticRelation _ _ -> expr
     ExistingRelation _ -> expr
     RelationVariable _ _ -> expr
+    With _ _ -> expr
     Project attrs subexpr -> 
       Project attrs (applyStaticRestrictionCollapse subexpr)
     Union sub1 sub2 ->
@@ -420,6 +423,7 @@ applyStaticRestrictionPushdown expr = case expr of
   MakeStaticRelation _ _ -> expr
   ExistingRelation _ -> expr
   RelationVariable _ _ -> expr
+  With _ _ -> expr
   Project _ _ -> expr
   --this transformation cannot be inverted because the projection attributes might not exist in the inverted version
   Restrict restrictAttrs (Project projAttrs subexpr) -> 


### PR DESCRIPTION
I've made a first pass, using the relation expression state.
I use AS instead of := at a first pass just try to help me implement it from SQL WITH. However, It can be changed for any good reason.
It supports multiple views. However, it can only reference previous ones.

```
TutorialD (master/main): :importexample date
TutorialD (master/main): :showexpr WITH (a AS s{s#,city}, b AS a{city}) b
┌──────────┐
│city::Text│
├──────────┤
│"Paris"   │
│"London"  │
│"Athens"  │
└──────────┘
```
