### PR TITLE
Add support for deriving Tupleable instances with custom options.

### DIFF
--- a/docs/tupleable.markdown
+++ b/docs/tupleable.markdown
@@ -23,6 +23,25 @@ instance Tupleable Person
 
 Now, ```Person``` values can be marshaled between the database and the client. The attribute names appearing in the Haskell data type will appear identically in the server with the same types.
 
+### Changing Options
+
+If our field names don't exactly match attribute names, but follow a common pattern, we can derive Tupleable with custom options. Let's say each field on person has a prefix "person", but we still want to use the attribute names without the prefix. We can make use of the ProjectM36.Tupleable module to accomplish our goal like so:
+
+```haskell
+import ProjectM36.Tupleable.Deriving
+
+data Person = Person {
+  personName :: Text,
+  personEmployeeNumber :: Int,
+  personLikesHorses :: Bool
+  }
+  deriving stock Generic
+  deriving Tupleable
+    via Codec (Field (DropPrefix "person" >>> CamelCase)) Person
+```
+
+The extensions DerivingGeneric, DerivingVia, TypeOperators, and DataKinds must be enabled for this code to compile. See the documentation on Hackage for all available options.
+
 ## Usage
 
 The ```Tupleable``` module includes the following functions:

--- a/examples/DerivingCustomTupleable.hs
+++ b/examples/DerivingCustomTupleable.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveGeneric, DerivingVia, GeneralizedNewtypeDeriving, TypeOperators, DataKinds, OverloadedStrings #-}
+
+import ProjectM36.Tupleable.Deriving
+import ProjectM36.Atomable (Atomable)
+import Control.DeepSeq (NFData)
+import Data.Binary (Binary)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+newtype BlogId = BlogId { getBlogId :: Int }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Num)
+
+instance NFData BlogId
+instance Binary BlogId
+instance Atomable BlogId
+
+data Blog = Blog
+  { blogId :: BlogId
+  , blogTitle :: Text
+  , blogAuthorName :: Text
+  }
+  deriving stock (Show, Generic)
+  deriving (Tupleable)
+    via Codec (Field (DropPrefix "blog" >>> CamelCase)) Blog
+
+data Comment = Comment
+  { commentAuthorName :: Text
+  , commentComment :: Text
+  , commentFor :: BlogId
+  }
+  deriving stock (Show, Generic)
+  deriving (Tupleable)
+    via Codec (Field (DropPrefix "comment" >>> CamelCase)) Comment
+
+main :: IO ()
+main = do
+  let exampleBlog = Blog
+        { blogId = 0
+        , blogTitle = "Cat Pics"
+        , blogAuthorName = "Alice"
+        }
+      exampleComment = Comment
+        { commentAuthorName = "Bob"
+        , commentComment = "great"
+        , commentFor = 0
+        }
+  print exampleBlog
+  print (toTuple exampleBlog)
+  putStrLn ""
+  print exampleComment
+  print (toTuple exampleComment)

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -411,11 +411,12 @@ Executable Example-CustomTupleable
     Main-Is: examples/CustomTupleable.hs
     GHC-Options: -Wall -threaded
 
-Executable Example-DerivingCustomTupleable
-    Default-Language: Haskell2010
-    Build-Depends: base, text, deepseq, binary, project-m36
-    Main-Is: examples/DerivingCustomTupleable.hs
-    GHC-Options: -Wall -threaded
+-- requires ghc >= 8.6.1
+-- Executable Example-DerivingCustomTupleable
+    -- Default-Language: Haskell2010
+    -- Build-Depends: base, text, deepseq, binary, project-m36
+    -- Main-Is: examples/DerivingCustomTupleable.hs
+    -- GHC-Options: -Wall -threaded
 
 Test-Suite test-scripts
     Default-Language: Haskell2010

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -34,7 +34,7 @@ Flag haskell-scripting
      Default: True
 
 Library
-    Build-Depends: base>=4.8 && < 4.14, ghc-paths, mtl, containers, unordered-containers, hashable, haskeline, directory, MonadRandom, random-shuffle, uuid >= 1.3.12, cassava >= 0.4.5.1 && < 0.6, text, bytestring, deepseq, deepseq-generics, vector, parallel, monad-parallel, exceptions, transformers, gnuplot, binary, filepath, zlib, directory, vector-binary-instances, temporary, stm, time, hashable-time, old-locale, rset, attoparsec, either, base64-bytestring, data-interval, extended-reals, network-transport, aeson >= 1.1, path-pieces, conduit, resourcet, http-api-data, semigroups, QuickCheck, quickcheck-instances, distributed-process-client-server >= 0.2.3, distributed-process >= 0.7.4, distributed-process-extras >= 0.3.2, distributed-process-async >= 0.2.4.1, network-transport-tcp >= 0.6.0, network-transport, list-t, stm-containers >= 0.2.15, foldl, optparse-applicative, Glob, cryptohash-sha256
+    Build-Depends: base>=4.8 && < 4.14, ghc-paths, mtl, containers, unordered-containers, hashable, haskeline, directory, MonadRandom, random-shuffle, uuid >= 1.3.12, cassava >= 0.4.5.1 && < 0.6, text, bytestring, deepseq, deepseq-generics, vector, parallel, monad-parallel, exceptions, transformers, gnuplot, binary, filepath, zlib, directory, vector-binary-instances, temporary, stm, time, hashable-time, old-locale, rset, attoparsec, either, base64-bytestring, data-interval, extended-reals, network-transport, aeson >= 1.1, path-pieces, conduit, resourcet, http-api-data, semigroups, QuickCheck, quickcheck-instances, distributed-process-client-server >= 0.2.3, distributed-process >= 0.7.4, distributed-process-extras >= 0.3.2, distributed-process-async >= 0.2.4.1, network-transport-tcp >= 0.6.0, network-transport, list-t, stm-containers >= 0.2.15, foldl, optparse-applicative, Glob, cryptohash-sha256, text-manipulate >= 0.2.0.1 && < 0.3
     if flag(haskell-scripting)
         Build-Depends: ghc >= 8.2 && < 8.9
         CPP-Options: -DPM36_HASKELL_SCRIPTING
@@ -89,6 +89,7 @@ Library
                      ProjectM36.AtomFunctions.Primitive,
                      ProjectM36.Atomable,
                      ProjectM36.Tupleable,
+                     ProjectM36.Tupleable.Deriving,
                      ProjectM36.DataConstructorDef,
                      ProjectM36.DataTypes.Basic,
                      ProjectM36.DataTypes.Sorting,
@@ -408,6 +409,12 @@ Executable Example-CustomTupleable
     Default-Extensions: OverloadedStrings
     Build-Depends: base, HUnit, Cabal, containers, hashable, unordered-containers, mtl, vector, vector-binary-instances, time, hashable-time, bytestring, uuid, stm, deepseq, deepseq-generics, binary, parallel, cassava, attoparsec, gnuplot, directory, temporary, haskeline, megaparsec, text, base64-bytestring, data-interval, filepath, transformers, stm-containers, list-t, aeson, path-pieces, either, conduit, http-api-data, template-haskell, ghc, ghc-paths, project-m36
     Main-Is: examples/CustomTupleable.hs
+    GHC-Options: -Wall -threaded
+
+Executable Example-DerivingCustomTupleable
+    Default-Language: Haskell2010
+    Build-Depends: base, text, deepseq, binary, project-m36
+    Main-Is: examples/DerivingCustomTupleable.hs
     GHC-Options: -Wall -threaded
 
 Test-Suite test-scripts

--- a/src/lib/ProjectM36/Tupleable.hs
+++ b/src/lib/ProjectM36/Tupleable.hs
@@ -178,7 +178,7 @@ class Tupleable a where
   toAttributes = genericToAttributes defaultTupleableOptions
 
 -- | Options that influence deriving behavior.
-data TupleableOptions = TupleableOptions {
+newtype TupleableOptions = TupleableOptions {
   -- | A function that translates record field names into attribute names.
   fieldModifier :: T.Text -> T.Text
   }

--- a/src/lib/ProjectM36/Tupleable.hs
+++ b/src/lib/ProjectM36/Tupleable.hs
@@ -6,7 +6,26 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
-module ProjectM36.Tupleable where
+module ProjectM36.Tupleable
+  ( toInsertExpr
+  , toDefineExpr
+  , tupleAssocsEqualityPredicate
+  , partitionByAttributes
+  , toUpdateExpr
+  , toDeleteExpr
+  , validateAttributes
+  , Tupleable(..)
+
+    -- * Generics
+  , genericToTuple
+  , genericFromTuple
+  , genericToAttributes
+  , TupleableG(..)
+    -- ** Options
+  , defaultTupleableOptions
+  , TupleableOptions()
+  , fieldModifier
+  ) where
 
 import           Data.Foldable
 import           Data.List                      (partition)
@@ -121,56 +140,109 @@ validateAttributes actualAttrs expectedAttrs val
   where
       nonMatchingAttrs = attributeNamesNotContained actualAttrs expectedAttrs
 
-
+-- | Types that can be converted to and from 'RelationTuple'.
+--
+-- deriving without customization:
+--
+-- > data Example = Example
+-- >     { foo :: Integer
+-- >     , bar :: Text
+-- >     }
+-- >     deriving (Generic)
+-- >
+-- > instance Tupleable Example
+--
+-- deriving with customization using "ProjectM36.Tupleable.Deriving":
+--
+-- > data Example = Example
+-- >     { exampleFoo :: Integer
+-- >     , exampleBar :: Text
+-- >     }
+-- >     deriving stock (Generic)
+-- >     deriving (Tupleable)
+-- >         via Codec (Field (DropPrefix "example" >>> CamelCase)) Example
 class Tupleable a where
   toTuple :: a -> RelationTuple
 
   fromTuple :: RelationTuple -> Either RelationalError a
 
-  toAttributes :: proxy a -> Attributes
+  toAttributes :: Proxy a -> Attributes
 
   default toTuple :: (Generic a, TupleableG (Rep a)) => a -> RelationTuple
-  toTuple v = toTupleG (from v)
+  toTuple = genericToTuple defaultTupleableOptions
 
   default fromTuple :: (Generic a, TupleableG (Rep a)) => RelationTuple -> Either RelationalError a
-  fromTuple tup = to <$> fromTupleG tup
+  fromTuple = genericFromTuple defaultTupleableOptions
 
-  default toAttributes :: (Generic a, TupleableG (Rep a)) => proxy a -> Attributes
-  toAttributes _ = toAttributesG (from (undefined :: a))
+  default toAttributes :: (Generic a, TupleableG (Rep a)) => Proxy a -> Attributes
+  toAttributes = genericToAttributes defaultTupleableOptions
+
+-- | Options that influence deriving behavior.
+data TupleableOptions = TupleableOptions {
+  -- | A function that translates record field names into attribute names.
+  fieldModifier :: T.Text -> T.Text
+  }
+
+-- | The default options for deriving Tupleable instances.
+--
+-- These options can be customized by using record update syntax. For example,
+--
+-- > defaultTupleableOptions
+-- >     { fieldModifier = \fieldName ->
+-- >         case Data.Text.stripPrefix "example" fieldName of
+-- >             Nothing -> fieldName
+-- >             Just attributeName -> attributeName
+-- >     }
+--
+-- will result in record field names being translated into attribute names by
+-- removing the prefix "example" from the field names.
+defaultTupleableOptions :: TupleableOptions
+defaultTupleableOptions = TupleableOptions {
+  fieldModifier = id
+  }
+
+genericToTuple :: (Generic a, TupleableG (Rep a)) => TupleableOptions -> a -> RelationTuple
+genericToTuple opts v = toTupleG opts (from v)
+
+genericFromTuple :: (Generic a, TupleableG (Rep a)) => TupleableOptions -> RelationTuple -> Either RelationalError a
+genericFromTuple opts tup = to <$> fromTupleG opts tup
+
+genericToAttributes :: forall a. (Generic a, TupleableG (Rep a)) => TupleableOptions -> Proxy a -> Attributes
+genericToAttributes opts _ = toAttributesG opts (from (undefined :: a))
 
 class TupleableG g where
-  toTupleG :: g a -> RelationTuple
-  toAttributesG :: g a -> Attributes
-  fromTupleG :: RelationTuple -> Either RelationalError (g a)
+  toTupleG :: TupleableOptions -> g a -> RelationTuple
+  toAttributesG :: TupleableOptions -> g a -> Attributes
+  fromTupleG :: TupleableOptions -> RelationTuple -> Either RelationalError (g a)
   isRecordTypeG :: g a -> Bool
 
 --data type metadata
 instance (Datatype c, TupleableG a) => TupleableG (M1 D c a) where
-  toTupleG (M1 v) = toTupleG v
-  toAttributesG (M1 v) = toAttributesG v
-  fromTupleG v = M1 <$> fromTupleG v
+  toTupleG opts (M1 v) = toTupleG opts v
+  toAttributesG opts (M1 v) = toAttributesG opts v
+  fromTupleG opts v = M1 <$> fromTupleG opts v
   isRecordTypeG (M1 v) = isRecordTypeG v
 
 --constructor metadata
 instance (Constructor c, TupleableG a, AtomableG a) => TupleableG (M1 C c a) where
-  toTupleG (M1 v) = RelationTuple attrs atoms
+  toTupleG opts (M1 v) = RelationTuple attrs atoms
     where
-      attrsToCheck = toAttributesG v
+      attrsToCheck = toAttributesG opts v
       counter = V.generate (V.length attrsToCheck) id
       attrs = V.zipWith (\num attr@(Attribute name typ) -> if T.null name then
                                                              Attribute ("attr" <> T.pack (show (num + 1))) typ
                                                            else
                                                              attr) counter attrsToCheck
       atoms = V.fromList (toAtomsG v)
-  toAttributesG (M1 v) = toAttributesG v
-  fromTupleG tup = M1 <$> fromTupleG tup
+  toAttributesG opts (M1 v) = toAttributesG opts v
+  fromTupleG opts tup = M1 <$> fromTupleG opts tup
   isRecordTypeG (M1 v) = isRecordTypeG v
 
 -- product types
 instance (TupleableG a, TupleableG b) => TupleableG (a :*: b) where
   toTupleG = error "toTupleG"
-  toAttributesG ~(x :*: y) = toAttributesG x V.++ toAttributesG y --a bit of extra laziness prevents whnf so that we can use toAttributes (undefined :: Test2T Int Int) without throwing an exception
-  fromTupleG tup = (:*:) <$> fromTupleG tup <*> fromTupleG processedTuple
+  toAttributesG opts ~(x :*: y) = toAttributesG opts x V.++ toAttributesG opts y --a bit of extra laziness prevents whnf so that we can use toAttributes (undefined :: Test2T Int Int) without throwing an exception
+  fromTupleG opts tup = (:*:) <$> fromTupleG opts tup <*> fromTupleG opts processedTuple
     where
       processedTuple = if isRecordTypeG (undefined :: a x) then
                          tup
@@ -181,18 +253,22 @@ instance (TupleableG a, TupleableG b) => TupleableG (a :*: b) where
 --selector/record
 instance (Selector c, AtomableG a) => TupleableG (M1 S c a) where
   toTupleG = error "toTupleG"
-  toAttributesG m@(M1 v) = V.singleton (Attribute name aType)
+  toAttributesG opts m@(M1 v) = V.singleton (Attribute modifiedName aType)
    where
      name = T.pack (selName m)
+     modifiedName = if T.null name then
+                      name
+                    else
+                      fieldModifier opts name
      aType = toAtomTypeG v
-  fromTupleG tup = if null name then -- non-record type, just pull off the first tuple item
+  fromTupleG opts tup = if null name then -- non-record type, just pull off the first tuple item
                      M1 <$> atomv (V.head (tupleAtoms tup))
                    else do
-                     atom <- atomForAttributeName (T.pack name) tup
+                     atom <- atomForAttributeName (fieldModifier opts (T.pack name)) tup
                      val <- atomv atom
                      pure (M1 val)
    where
-     expectedAtomType = atomType (V.head (toAttributesG (undefined :: M1 S c a x)))
+     expectedAtomType = atomType (V.head (toAttributesG opts (undefined :: M1 S c a x)))
      atomv atom = maybe (Left (AtomTypeMismatchError
                                expectedAtomType
                                (atomTypeForAtom atom)
@@ -203,8 +279,8 @@ instance (Selector c, AtomableG a) => TupleableG (M1 S c a) where
 --constructors with no arguments
 --basically useless but orthoganal to relationTrue
 instance TupleableG U1 where
-  toTupleG _= emptyTuple
-  toAttributesG _ = emptyAttributes
-  fromTupleG _ = pure U1
+  toTupleG _ _ = emptyTuple
+  toAttributesG _ _ = emptyAttributes
+  fromTupleG _ _ = pure U1
   isRecordTypeG _ = False
 

--- a/src/lib/ProjectM36/Tupleable/Deriving.hs
+++ b/src/lib/ProjectM36/Tupleable/Deriving.hs
@@ -56,6 +56,7 @@ module ProjectM36.Tupleable.Deriving
 import           Data.Proxy
 import qualified Data.Text            as T
 import           Data.Text.Manipulate
+import           Data.Maybe
 import           GHC.TypeLits
 import           GHC.Generics         (Generic, Rep)
 import           ProjectM36.Tupleable
@@ -128,7 +129,7 @@ instance KnownSymbol prefix => ModifyText (AddPrefix prefix) where
 data DropPrefix (prefix :: Symbol)
 
 instance KnownSymbol prefix => ModifyText (DropPrefix prefix) where
-  modifyText _ oldText = maybe oldText id (T.stripPrefix prefixText oldText)
+  modifyText _ oldText = fromMaybe oldText (T.stripPrefix prefixText oldText)
     where
       prefixText = T.pack (symbolVal (Proxy :: Proxy prefix))
 
@@ -144,7 +145,7 @@ instance KnownSymbol suffix => ModifyText (AddSuffix suffix) where
 data DropSuffix (suffix :: Symbol)
 
 instance KnownSymbol suffix => ModifyText (DropSuffix suffix) where
-  modifyText _ oldText = maybe oldText id (T.stripSuffix suffixText oldText)
+  modifyText _ oldText = fromMaybe oldText (T.stripSuffix suffixText oldText)
     where
       suffixText = T.pack (symbolVal (Proxy :: Proxy suffix))
 

--- a/src/lib/ProjectM36/Tupleable/Deriving.hs
+++ b/src/lib/ProjectM36/Tupleable/Deriving.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Newtypes for deriving Tupleable instances with customization using
+-- @DerivingVia@.
+--
+-- Inspired by
+-- [Dhall.Deriving](https://hackage.haskell.org/package/dhall-1.33.1/docs/Dhall-Deriving.html)
+-- which in turn was inspired by Matt Parson's blog post
+-- [Mirror Mirror: Reflection and Encoding Via](https://www.parsonsmatt.org/2020/02/04/mirror_mirror.html).
+--
+-- required extensions:
+--
+--   * DerivingVia
+--   * DeriveGenerics
+--   * TypeOperators (for @('<<<')@ and @('>>>')@)
+--   * DataKinds (for types that take a string argument)
+
+module ProjectM36.Tupleable.Deriving
+  ( -- * DerivingVia Newtype
+    Codec(..)
+
+    -- * Type-level Options
+  , ModifyOptions(..)
+  , Field
+
+    -- * Type-level 'T.Text' -> 'T.Text' Functions
+  , ModifyText(..)
+  , AddPrefix
+  , DropPrefix
+  , AddSuffix
+  , DropSuffix
+  , UpperCase
+  , LowerCase
+  , TitleCase
+  , CamelCase
+  , PascalCase
+  , SnakeCase
+  , SpinalCase
+  , TrainCase
+
+    -- * Composition
+  , AsIs
+  , type (<<<)
+  , type (>>>)
+
+    -- * Re-Exports
+  , Generic
+  , module ProjectM36.Tupleable
+  ) where
+
+import           Data.Proxy
+import qualified Data.Text            as T
+import           Data.Text.Manipulate
+import           GHC.TypeLits
+import           GHC.Generics         (Generic, Rep)
+import           ProjectM36.Tupleable
+
+-- | A newtype wrapper to allow for easier deriving of 'Tupleable' instances
+-- with customization.
+--
+-- The @tag@ type variable can be used to specify options for converting the
+-- datatype to and from a 'RelationTuple'. For example,
+--
+-- > data Example = Example
+-- >     { exampleFoo :: Int
+-- >     , exampleBar :: Int
+-- >     }
+-- >     deriving stock (Generic)
+-- >     deriving (Tupleable)
+-- >         via Codec (Field (DropPrefix "example" >>> CamelCase)) Example
+--
+-- will derive an instance of 'Tupleable' where field names are translated into
+-- attribute names by dropping the prefix @"example"@ and then converting the
+-- result to camelCase. So @"exampleFoo"@ becomes @"foo"@ and @"exampleBar"@
+-- becomes @"bar"@.
+--
+-- Requires the @DerivingGeneric@ and @DerivingVia@ extensions to be enabled.
+newtype Codec tag a = Codec { unCodec :: a }
+
+instance (ModifyOptions tag, Generic a, TupleableG (Rep a)) => Tupleable (Codec tag a) where
+  toTuple v = genericToTuple opts (unCodec v)
+    where
+      opts = modifyOptions (Proxy :: Proxy tag) defaultTupleableOptions
+
+  fromTuple tup = Codec <$> genericFromTuple opts tup
+    where
+      opts = modifyOptions (Proxy :: Proxy tag) defaultTupleableOptions
+
+  toAttributes _ = genericToAttributes opts (Proxy :: Proxy a)
+    where
+      opts = modifyOptions (Proxy :: Proxy tag) defaultTupleableOptions
+
+-- | Types that can be used as tags for 'Codec'.
+class ModifyOptions a where
+  modifyOptions :: proxy a -> TupleableOptions -> TupleableOptions
+
+-- | Change how record field names are translated into attribute names. For
+-- example,
+--
+-- > Field SnakeCase
+--
+-- will translate the field name @fooBar@ into the attribute name @foo_bar@.
+data Field a
+
+instance ModifyText a => ModifyOptions (Field a) where
+  modifyOptions _ opts = opts { fieldModifier = newFieldModifier }
+    where
+      newFieldModifier = modifyText (Proxy :: Proxy a) . fieldModifier opts
+
+-- | Types that can be used in options that modify 'T.Text' such as in 'Field'.
+class ModifyText a where
+  modifyText :: proxy a -> T.Text -> T.Text
+
+-- | Add a prefix. @AddPrefix "foo"@ will transform @"bar"@ into @"foobar"@.
+data AddPrefix (prefix :: Symbol)
+
+instance KnownSymbol prefix => ModifyText (AddPrefix prefix) where
+  modifyText _ oldText = prefixText <> oldText
+    where
+      prefixText = T.pack (symbolVal (Proxy :: Proxy prefix))
+
+-- | Drop a prefix. @DropPrefix "bar"@ will transform @"foobar"@ into @"foo"@.
+data DropPrefix (prefix :: Symbol)
+
+instance KnownSymbol prefix => ModifyText (DropPrefix prefix) where
+  modifyText _ oldText = maybe oldText id (T.stripPrefix prefixText oldText)
+    where
+      prefixText = T.pack (symbolVal (Proxy :: Proxy prefix))
+
+-- | Add a suffix. @AddSuffix "bar"@ will transform @"foo"@ into @"foobar"@.
+data AddSuffix (suffix :: Symbol)
+
+instance KnownSymbol suffix => ModifyText (AddSuffix suffix) where
+  modifyText _ oldText = oldText <> suffixText
+    where
+      suffixText = T.pack (symbolVal (Proxy :: Proxy suffix))
+
+-- | Drop a suffix. @DropSuffix "bar"@ will transform @"foobar"@ into @"foo"@.
+data DropSuffix (suffix :: Symbol)
+
+instance KnownSymbol suffix => ModifyText (DropSuffix suffix) where
+  modifyText _ oldText = maybe oldText id (T.stripSuffix suffixText oldText)
+    where
+      suffixText = T.pack (symbolVal (Proxy :: Proxy suffix))
+
+-- | Convert to UPPERCASE. Will transform @"foobar"@ into @\"FOOBAR\"@.
+data UpperCase
+
+instance ModifyText UpperCase where
+  modifyText _ = T.toUpper
+
+-- | Convert to lowercase. Will transform @\"FOOBAR\"@ into @"foobar"@.
+data LowerCase
+
+instance ModifyText LowerCase where
+  modifyText _ = T.toLower
+
+-- | Convert to Title Case. Will transform @"fooBar"@ into @\"Foo Bar\"@.
+data TitleCase
+
+instance ModifyText TitleCase where
+  modifyText _ = toTitle
+
+-- | Convert to camelCase. Will transform @"foo_bar"@ into @"fooBar"@.
+data CamelCase
+
+instance ModifyText CamelCase where
+  modifyText _ = toCamel
+
+-- | Convert to PascalCase. Will transform @"foo_bar"@ into @\"FooBar\"@.
+data PascalCase
+
+instance ModifyText PascalCase where
+  modifyText _ = toPascal
+
+-- | Convert to snake_case. Will transform @"fooBar"@ into @"foo_bar"@.
+data SnakeCase
+
+instance ModifyText SnakeCase where
+  modifyText _ = toSnake
+
+-- | Convert to spinal-case. will transform @"fooBar"@ into @"foo-bar"@.
+data SpinalCase
+
+instance ModifyText SpinalCase where
+  modifyText _ = toSpinal
+
+-- | Convert to Train-Case. Will transform @"fooBar"@ into @\"Foo-Bar\"@.
+data TrainCase
+
+instance ModifyText TrainCase where
+  modifyText _ = toTrain
+
+-- | Identity option.
+type AsIs = ()
+
+instance ModifyOptions () where
+  modifyOptions _ = id
+
+instance ModifyText () where
+  modifyText _ = id
+
+-- | Right to left composition.
+--
+-- Requires the @TypeOperators@ extension to be enabled.
+data a <<< b
+
+instance (ModifyOptions a, ModifyOptions b) => ModifyOptions (a <<< b) where
+  modifyOptions _ = modifyOptions (Proxy :: Proxy a) . modifyOptions (Proxy :: Proxy b)
+
+instance (ModifyText a, ModifyText b) => ModifyText (a <<< b) where
+  modifyText _ = modifyText (Proxy :: Proxy a) . modifyText (Proxy :: Proxy b)
+
+-- | Left to right composition.
+--
+-- Requires the @TypeOperators@ extension to be enabled.
+data a >>> b
+
+instance (ModifyOptions a, ModifyOptions b) => ModifyOptions (a >>> b) where
+  modifyOptions _ = modifyOptions (Proxy :: Proxy b) . modifyOptions (Proxy :: Proxy a)
+
+instance (ModifyText a, ModifyText b) => ModifyText (a >>> b) where
+  modifyText _ = modifyText (Proxy :: Proxy b) . modifyText (Proxy :: Proxy a)


### PR DESCRIPTION
Takes advantage of the DerivingVia extension to allow for deriving Tupleable instances with custom options. Note that the type of `toAttributes` is changed from `proxy a -> Attributes` to `Proxy a -> Attributes`

fixes #163