### PR TITLE
make tests compile for GHC < 8.6.1

### DIFF
--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -43,8 +43,6 @@ Library
         ghc-boot, ghci
     if impl(ghc>= 8.6)
         Build-Depends: deferred-folds
-    if impl(ghc>= 8.6.1)
-        Exposed-Modules: ProjectM36.Tupleable.Deriving
     Exposed-Modules: ProjectM36.Error,
                      ProjectM36.Transaction,
                      ProjectM36.TransactionGraph,
@@ -91,6 +89,7 @@ Library
                      ProjectM36.AtomFunctions.Primitive,
                      ProjectM36.Atomable,
                      ProjectM36.Tupleable,
+                     ProjectM36.Tupleable.Deriving,
                      ProjectM36.DataConstructorDef,
                      ProjectM36.DataTypes.Basic,
                      ProjectM36.DataTypes.Sorting,


### PR DESCRIPTION
I included a conditional in the cabal file of my earlier pull request that causes the tests not to compile for GHC < 8.6.1. I had realized that it's not necessary, but accidentally included it in the pull request. All features actually used in the module are available before GHC 8.6, it's just not very useful without DerivingVia which was introduced in GHC 8.6.1. Sorry about that, I should have been more careful.