### PR TITLE
Fixed typo in introduction_to_the_relational_algebra.markdown

### DIFF
--- a/docs/introduction_to_the_relational_algebra.markdown
+++ b/docs/introduction_to_the_relational_algebra.markdown
@@ -202,7 +202,7 @@ Join (Instructor relation)
 
 (Course Relation)
 
-|(Course Name, Course Name Type)|(Instructor, Instructor Name Type)|(Course Room Number, Room Number Type)|
+|(Course Name, Course Name Type)|(Instructor Name, Instructor Name Type)|(Course Room Number, Room Number Type)|
 |-------------------------------|----------------------------------|--------------------------------------|
 |English 1|Steve|Room 104|
 |French 2|Bob|Room 103|


### PR DESCRIPTION
The column names didn’t match.