### PR TITLE
Added 'integer' atom function

### DIFF
--- a/src/lib/ProjectM36/AtomFunctions/Primitive.hs
+++ b/src/lib/ProjectM36/AtomFunctions/Primitive.hs
@@ -50,8 +50,10 @@ primitiveAtomFunctions = HS.fromList [
                                                    pure (IntAtom (fromIntegral v))
                                                  else
                                                    Left InvalidIntBoundError
-                                                   }
-  
+                                                   },
+  AtomFunction { atomFuncName = "integer",
+                 atomFuncType = [IntAtomType, IntegerAtomType],
+                 atomFuncBody = body $ \(IntAtom v:_) -> Right $ IntegerAtom $ fromIntegral v}
   ]
   where
     body = AtomFunctionBody Nothing


### PR DESCRIPTION
We had `int :: Integer -> Int` and were missing the opposite