### PR TITLE
312 object loaded functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: project-m36
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/docs/atomfunctions.markdown
+++ b/docs/atomfunctions.markdown
@@ -66,9 +66,15 @@ Finally, connect to your Project:M36 database using the `tutd` client and run:
 
 `TutorialD (master/main): loadatomfunctions "DynamicAtomFunctions" "someFunctions" "examples/DynamicAtomFunctions.o"`
 
+Note that persistent databases (which keep the database on disk) include an additional security feature which ensures that the object file is present within the database directory. This ensures that only the database owner can load object modules and also that the module does not get lost elsewhere in the filesystem. 
+
+If your database is running in persistent mode, then loading the object modules is slightly different. First, copy the compiled object file into  `<database directory>/compiled_modules`, then:
+
+`TutorialD (master/main): loadatomfunctions "DynamicAtomFunctions" "someFunctions" "DynamicAtomFunctions.o"`
+
 If you see an error such as "unknown symbol", the version of the "project-m36" library installed in your sandbox is different from that with which you linked the object file. Make sure that the same versions are used in linking the server and object file.
 
-The atom function is now loaded and ready-to-use. Note, however, that the function must be added every time the project-m36-server starts. This will probably be improved in a future release.
+The atom function is now loaded and ready-to-use.
 
 ## Differences when compared to other DBMSes
 

--- a/docs/database_context_functions.markdown
+++ b/docs/database_context_functions.markdown
@@ -127,7 +127,7 @@ import qualified Data.Map as M
 
 
 someDBCFunctions :: [DatabaseContextFunction]
-someDBCFunctions = [DatabaseContextFunction {
+someDBCFunctions = [tFunction {
                        dbcFuncName = "addtestrel",
                        dbcFuncType = [],
                        dbcFuncBody = DatabaseContextFunctionBody Nothing addTestRel
@@ -158,9 +158,13 @@ Finally, connect to your database with `tutd` and load the module:
 TutorialD (master/main): loaddatabasecontextfunctions "DynamicDatabaseContextFunctions" "someDBCFunctions" "examples/DynamicDatabaseContextFunctions.o"
 ```
 
-If the load reports an "unknown symbol" error, double check that the installed "project-m36" package is identical to one used to link the Haskell module.
+or, if running the database in persistent mode, copy the compiled module ".o" file into `<database directory>/compiled_modules/`, then:
 
-Note that such functions do not survive a server restart; this will likely be improved in a future release.
+```
+TutorialD (master/main): loaddatabasecontextfunctions "DynamicDatabaseContextFunctions" "someDBCFunctions" "DynamicDatabaseContextFunctions.o"
+```
+
+If the load reports an "unknown symbol" error, double check that the installed "project-m36" package is identical to one used to link the Haskell module.
 
 ## Future Improvements
 

--- a/docs/database_context_functions.markdown
+++ b/docs/database_context_functions.markdown
@@ -114,12 +114,15 @@ from the same module.
 
 ## Loading Precompiled Modules
 
+*WARNING* Loading object files into the database can be a security and/or and database integrity issue. Project:M36 relies on calculating past states of the database. For this reason, it is inadvisable to alter object files once they are loaded into a database. Changing these object files could corrupt the database. Treat object files loaded as read-only. Use version numbers in the object file names to allow for future revisions.
+
 Database context functions compiled with GHC to object files can be loaded at runtime. Let's walk through an example:
 
 ```haskell
 module DynamicDatabaseContextFunctions where
 import ProjectM36.Base
 import ProjectM36.Relation
+import ProjectM36.DatabaseContextFunction
 import ProjectM36.DatabaseContextFunctionError
 import qualified ProjectM36.Attribute as A
 
@@ -127,19 +130,19 @@ import qualified Data.Map as M
 
 
 someDBCFunctions :: [DatabaseContextFunction]
-someDBCFunctions = [tFunction {
-                       dbcFuncName = "addtestrel",
-                       dbcFuncType = [],
-                       dbcFuncBody = DatabaseContextFunctionBody Nothing addTestRel
+someDBCFunctions = [Function {
+                       funcName = "addtestrel",
+                       funcType = [],
+                       funcBody = externalDatabaseContextFunction addTestRel
                        }]
   where
     addTestRel _ ctx = do
-      let attrs = A.attributesFromList [Attribute "word" TextAtomType]
-          eRel = mkRelationFromList attrs [[TextAtom "nice"]]
-      case eRel of
-        Left err -> Left (DatabaseContextFunctionUserError (show err))
-        Right testRel ->
-          pure $ ctx { relationVariables = M.insert "testRel" testRel (relationVariables ctx) }
+      let attrExprs = [NakedAttributeExpr (Attribute "word" TextAtomType)]
+          newRelExpr = MakeRelationFromExprs (Just attrExprs) (TupleExprs UncommittedContextMa\
+rker [TupleExpr (M.singleton "word" (NakedAtomExpr (TextAtom "nice")))])
+      pure $ ctx { relationVariables =
+                       M.insert "testRel" (newRelExpr) (relationVariables ctx) }
+
 ```
 
 The function returns a list of `DatabaseContextFunction`s (just one in this case). The function adds a relation variable to the current database context.
@@ -150,7 +153,15 @@ Compile it with GHC:
 cabal exec ghc -- examples/DynamicDatabaseContextFunctions.hs -package project-m36
 ```
 
-or invoked GHC via stack.
+or invoke GHC via stack.
+
+You can also compile it into a shared object file if you link against modules which do not ship with Project:M36.
+
+```
+cabal exec ghc -- examples/DynamicDatabaseContextFunctions.hs -package project-m36 -package <another package> -fPIC -shared -dynamic -o examples/DynamicDatabaseContextFunctions.so
+```
+
+
 
 Finally, connect to your database with `tutd` and load the module:
 

--- a/examples/DynamicAtomFunctions.hs
+++ b/examples/DynamicAtomFunctions.hs
@@ -10,7 +10,7 @@ import ProjectM36.Base
 import ProjectM36.AtomFunction
 
 someAtomFunctions :: [AtomFunction]
-someAtomFunctions = [AtomFunction{
-                    atomFuncName = "constTrue",
-                    atomFuncType = [TypeVariableType "a", BoolAtomType],
-                    atomFuncBody = externalAtomFunction (\(x:_) -> pure (BoolAtom True))}]
+someAtomFunctions = [Function{
+                    funcName = "constTrue",
+                    funcType = [TypeVariableType "a", BoolAtomType],
+                    funcBody = externalAtomFunction (\(x:_) -> pure (BoolAtom True))}]

--- a/examples/DynamicAtomFunctions.hs
+++ b/examples/DynamicAtomFunctions.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 --compile with `cabal exec ghc -- examples/DynamicAtomFunctions.hs -package project-m36`
---load with `loadatomfunctions "DynamicAtomFunctions" "someAtomFunctions" "examples/DynamicAtomFunctions.o"`
+-- for persistent databases, copy "DynamicAtomFunctions.o" to "<db dir>/compiled_modules", then
+--    load with `loadatomfunctions "DynamicAtomFunctions" "someAtomFunctions" "DynamicAtomFunctions.o"`
+-- for transient databases,
+--    load with `loadatomfunctions "DynamicAtomFunctions" "someAtomFunctions" "examples/DynamicAtomFunctions.o"`
 
 module DynamicAtomFunctions where
 import ProjectM36.Base
+import ProjectM36.AtomFunction
 
 someAtomFunctions :: [AtomFunction]
 someAtomFunctions = [AtomFunction{
                     atomFuncName = "constTrue",
                     atomFuncType = [TypeVariableType "a", BoolAtomType],
-                    atomFuncBody = AtomFunctionBody Nothing (\(x:_) -> pure (BoolAtom True))}]
+                    atomFuncBody = externalAtomFunction (\(x:_) -> pure (BoolAtom True))}]

--- a/examples/DynamicDatabaseContextFunctions.hs
+++ b/examples/DynamicDatabaseContextFunctions.hs
@@ -4,6 +4,7 @@
 module DynamicDatabaseContextFunctions where
 import ProjectM36.Base
 import ProjectM36.Relation
+import ProjectM36.DatabaseContextFunction
 import ProjectM36.DatabaseContextFunctionError
 import qualified ProjectM36.Attribute as A
 
@@ -11,16 +12,16 @@ import qualified Data.Map as M
 
 
 someDBCFunctions :: [DatabaseContextFunction]
-someDBCFunctions = [DatabaseContextFunction {
-                       dbcFuncName = "addtestrel",
-                       dbcFuncType = [],
-                       dbcFuncBody = DatabaseContextFunctionBody Nothing addTestRel
+someDBCFunctions = [Function {
+                       funcName = "addtestrel",
+                       funcType = [],
+                       funcBody = externalDatabaseContextFunction addTestRel
                        }]
   where
     addTestRel _ ctx = do
-      let attrs = A.attributesFromList [Attribute "word" TextAtomType]
-          eRel = mkRelationFromList attrs [[TextAtom "nice"]] 
-      case eRel of 
-        Left err -> Left (DatabaseContextFunctionUserError (show err))
-        Right testRel ->
-          pure $ ctx { relationVariables = M.insert "testRel" testRel (relationVariables ctx) }
+      let attrExprs = [NakedAttributeExpr (Attribute "word" TextAtomType)]
+          newRelExpr = MakeRelationFromExprs (Just attrExprs) (TupleExprs UncommittedContextMarker [TupleExpr (M.singleton "word" (NakedAtomExpr (TextAtom "nice")))])
+      pure $ ctx { relationVariables =
+                       M.insert "testRel" (newRelExpr) (relationVariables ctx) }      
+
+

--- a/examples/DynamicDatabaseContextFunctions.hs
+++ b/examples/DynamicDatabaseContextFunctions.hs
@@ -22,6 +22,6 @@ someDBCFunctions = [Function {
       let attrExprs = [NakedAttributeExpr (Attribute "word" TextAtomType)]
           newRelExpr = MakeRelationFromExprs (Just attrExprs) (TupleExprs UncommittedContextMarker [TupleExpr (M.singleton "word" (NakedAtomExpr (TextAtom "nice")))])
       pure $ ctx { relationVariables =
-                       M.insert "testRel" (newRelExpr) (relationVariables ctx) }      
+                       M.insert "testRel" newRelExpr (relationVariables ctx) }      
 
 

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -59,6 +59,7 @@ Library
                      ProjectM36.AttributeNames,
                      ProjectM36.Tuple,
                      ProjectM36.TupleSet,
+                     ProjectM36.Function,
                      ProjectM36.Atom,
                      ProjectM36.AtomFunction,
                      ProjectM36.AtomFunctionError,

--- a/src/bin/TutorialD/Interpreter/Base.hs
+++ b/src/bin/TutorialD/Interpreter/Base.hs
@@ -43,7 +43,6 @@ import Control.Monad.Random
 import Data.List.NonEmpty as NE
 import Data.Time.Clock
 import Data.Time.Format
-import Control.Monad (void)
 import Data.Char
 
 #if !MIN_VERSION_megaparsec(7,0,0)

--- a/src/bin/TutorialD/Interpreter/DatabaseContextExpr.hs
+++ b/src/bin/TutorialD/Interpreter/DatabaseContextExpr.hs
@@ -182,9 +182,9 @@ removeDatabaseContextFunctionP = do
 executeDatabaseContextFunctionP :: Parser DatabaseContextExpr
 executeDatabaseContextFunctionP = do
   reserved "execute"
-  funcName <- functionNameP
+  funcName' <- functionNameP
   args <- parens (sepBy atomExprP comma)
-  pure (ExecuteDatabaseContextFunction funcName args)
+  pure (ExecuteDatabaseContextFunction funcName' args)
   
 databaseExprOpP :: Parser DatabaseContextExpr
 databaseExprOpP = multipleDatabaseContextExprP

--- a/src/bin/TutorialD/Interpreter/DatabaseContextIOOperator.hs
+++ b/src/bin/TutorialD/Interpreter/DatabaseContextIOOperator.hs
@@ -24,9 +24,9 @@ createArbitraryRelationP = do
 dbioexprP :: ParseStr -> (Text -> [TypeConstructor] -> Text -> DatabaseContextIOExpr) -> Parser DatabaseContextIOExpr
 dbioexprP res adt = do
   reserved res
-  funcName <- quotedString
-  funcType <- atomTypeSignatureP
-  adt funcName funcType <$> quotedString
+  funcName' <- quotedString
+  funcType' <- atomTypeSignatureP
+  adt funcName' funcType' <$> quotedString
 
 atomTypeSignatureP :: Parser [TypeConstructor]
 atomTypeSignatureP = sepBy typeConstructorP arrow

--- a/src/bin/TutorialD/Interpreter/Types.hs
+++ b/src/bin/TutorialD/Interpreter/Types.hs
@@ -19,7 +19,7 @@ dataConstructorNameP = capitalizedIdentifier
 attributeNameP :: Parser AttributeName
 attributeNameP = uncapitalizedIdentifier
 
-functionNameP :: Parser AtomFunctionName
+functionNameP :: Parser FunctionName
 functionNameP = uncapitalizedIdentifier
 
 -- | Upper case names are type names while lower case names are polymorphic typeconstructor arguments.

--- a/src/lib/ProjectM36/AtomFunction.hs
+++ b/src/lib/ProjectM36/AtomFunction.hs
@@ -76,7 +76,7 @@ createScriptedAtomFunction funcName argsType retType = AddAtomFunction funcName 
 
 loadAtomFunctions :: ModName -> FuncName -> FilePath -> IO (Either LoadSymbolError [AtomFunction])
 #ifdef PM36_HASKELL_SCRIPTING
-loadAtomFunctions = loadFunction
+loadAtomFunctions = loadFunction LoadAutoObjectFile
 #else
 loadAtomFunctions _ _ _ = pure (Left LoadSymbolError)
 #endif

--- a/src/lib/ProjectM36/AtomFunction.hs
+++ b/src/lib/ProjectM36/AtomFunction.hs
@@ -6,7 +6,6 @@ import ProjectM36.Error
 import ProjectM36.Relation
 import ProjectM36.AtomType
 import ProjectM36.AtomFunctionError
-import ProjectM36.ScriptSession
 import ProjectM36.Function
 import qualified ProjectM36.Attribute as A
 import qualified Data.HashSet as HS
@@ -70,9 +69,10 @@ createScriptedAtomFunction funcName' argsType retType = AddAtomFunction funcName
                 ADTypeConstructor "AtomFunctionError" [],                     
                 retType]])
 
+{-
 loadAtomFunctions :: ModName -> FuncName -> Maybe FilePath -> FilePath -> IO (Either LoadSymbolError [AtomFunction])
 #ifdef PM36_HASKELL_SCRIPTING
-loadAtomFunctions modName funcName' mModDir objPath =
+Loadatomfunctions modName funcName' mModDir objPath =
   case mModDir of
     Just modDir -> do
       eNewFs <- loadFunctionFromDirectory LoadAutoObjectFile modName funcName' modDir objPath
@@ -89,6 +89,7 @@ loadAtomFunctions modName funcName' mModDir objPath =
 #else
 loadAtomFunctions _ _ _ _ = pure (Left LoadSymbolError)
 #endif
+-}
 
 atomFunctionsAsRelation :: AtomFunctions -> Either RelationalError Relation
 atomFunctionsAsRelation funcs = mkRelationFromList attrs tups
@@ -111,13 +112,6 @@ hashBytes func = BL.fromChunks [serialise (funcName func),
                 FunctionBuiltInBody _ -> ""
                 FunctionObjectLoadedBody f m n _ -> serialise (f,m,n)
   
--- | Change atom function definition to reference proper object file source. Useful when moving the object file into the database directory.
-processObjectLoadedFunctionBody :: ObjectModuleName -> ObjectFileEntryFunctionName -> FilePath -> AtomFunctionBody -> AtomFunctionBody
-processObjectLoadedFunctionBody modName fentry objPath body =
-  FunctionObjectLoadedBody objPath modName fentry f
-  where
-    f = function body
-
 -- | Used to mark functions which are loaded externally from the server.      
 externalAtomFunction :: AtomFunctionBodyType -> AtomFunctionBody
 externalAtomFunction = FunctionBuiltInBody

--- a/src/lib/ProjectM36/AtomFunctionBody.hs
+++ b/src/lib/ProjectM36/AtomFunctionBody.hs
@@ -4,4 +4,4 @@ module ProjectM36.AtomFunctionBody where
 import ProjectM36.Base
 
 compiledAtomFunctionBody :: AtomFunctionBodyType -> AtomFunctionBody  
-compiledAtomFunctionBody = AtomFunctionBuiltInBody
+compiledAtomFunctionBody = FunctionBuiltInBody

--- a/src/lib/ProjectM36/AtomFunctionBody.hs
+++ b/src/lib/ProjectM36/AtomFunctionBody.hs
@@ -4,4 +4,4 @@ module ProjectM36.AtomFunctionBody where
 import ProjectM36.Base
 
 compiledAtomFunctionBody :: AtomFunctionBodyType -> AtomFunctionBody  
-compiledAtomFunctionBody = AtomFunctionBody Nothing
+compiledAtomFunctionBody = AtomFunctionBuiltInBody

--- a/src/lib/ProjectM36/AtomFunctions/Primitive.hs
+++ b/src/lib/ProjectM36/AtomFunctions/Primitive.hs
@@ -11,50 +11,52 @@ import Control.Monad
 primitiveAtomFunctions :: AtomFunctions
 primitiveAtomFunctions = HS.fromList [
   --match on any relation type
-  AtomFunction { atomFuncName = "add",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, IntegerAtomType],
-                 atomFuncBody = body (\(IntegerAtom i1:IntegerAtom i2:_) -> pure (IntegerAtom (i1 + i2)))},
-  AtomFunction { atomFuncName = "id",
-                 atomFuncType = [TypeVariableType "a", TypeVariableType "a"],
-                 atomFuncBody = body (\(x:_) -> pure x)},
-  AtomFunction { atomFuncName = "sum",
-                 atomFuncType = foldAtomFuncType IntegerAtomType IntegerAtomType,
-                 atomFuncBody = body (\(RelationAtom rel:_) -> relationSum rel)},
-  AtomFunction { atomFuncName = "count",
-                 atomFuncType = foldAtomFuncType (TypeVariableType "a") IntegerAtomType,
-                 atomFuncBody = body (\(RelationAtom relIn:_) -> relationCount relIn)},
-  AtomFunction { atomFuncName = "max",
-                 atomFuncType = foldAtomFuncType IntegerAtomType IntegerAtomType,
-                 atomFuncBody = body (\(RelationAtom relIn:_) -> relationMax relIn)},
-  AtomFunction { atomFuncName = "min",
-                 atomFuncType = foldAtomFuncType IntegerAtomType IntegerAtomType,
-                 atomFuncBody = body (\(RelationAtom relIn:_) -> relationMin relIn)},
-  AtomFunction { atomFuncName = "lt",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
-                 atomFuncBody = body $ integerAtomFuncLessThan False},
-  AtomFunction { atomFuncName = "lte",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
-                 atomFuncBody = body $ integerAtomFuncLessThan True},
-  AtomFunction { atomFuncName = "gte",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
-                 atomFuncBody = body $ integerAtomFuncLessThan False >=> boolAtomNot},
-  AtomFunction { atomFuncName = "gt",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
-                 atomFuncBody = body $ integerAtomFuncLessThan True >=> boolAtomNot},
-  AtomFunction { atomFuncName = "not",
-                 atomFuncType = [BoolAtomType, BoolAtomType],
-                 atomFuncBody = body $ \(b:_) -> boolAtomNot b },
-  AtomFunction { atomFuncName = "int",
-                 atomFuncType = [IntegerAtomType, IntAtomType],
-                 atomFuncBody = body $ \(IntegerAtom v:_) -> if v < fromIntegral (maxBound :: Int) then
-                                                   pure (IntAtom (fromIntegral v))
-                                                 else
-                                                   Left InvalidIntBoundError
-                                                   }
-  
+  Function { funcName = "add",
+             funcType = [IntegerAtomType, IntegerAtomType, IntegerAtomType],
+             funcBody = body (\(IntegerAtom i1:IntegerAtom i2:_) -> pure (IntegerAtom (i1 + i2)))},
+    Function { funcName = "id",
+               funcType = [TypeVariableType "a", TypeVariableType "a"],
+               funcBody = body (\(x:_) -> pure x)},
+    Function { funcName = "sum",
+               funcType = foldAtomFuncType IntegerAtomType IntegerAtomType,
+               funcBody = body (\(RelationAtom rel:_) -> relationSum rel)},
+    Function { funcName = "count",
+               funcType = foldAtomFuncType (TypeVariableType "a") IntegerAtomType,
+               funcBody = body (\(RelationAtom relIn:_) -> relationCount relIn)},
+    Function { funcName = "max",
+               funcType = foldAtomFuncType IntegerAtomType IntegerAtomType,
+               funcBody = body (\(RelationAtom relIn:_) -> relationMax relIn)},
+    Function { funcName = "min",
+               funcType = foldAtomFuncType IntegerAtomType IntegerAtomType,
+               funcBody = body (\(RelationAtom relIn:_) -> relationMin relIn)},
+    Function { funcName = "lt",
+               funcType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
+               funcBody = body $ integerAtomFuncLessThan False},
+    Function { funcName = "lte",
+               funcType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
+               funcBody = body $ integerAtomFuncLessThan True},
+    Function { funcName = "gte",
+               funcType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
+               funcBody = body $ integerAtomFuncLessThan False >=> boolAtomNot},
+    Function { funcName = "gt",
+               funcType = [IntegerAtomType, IntegerAtomType, BoolAtomType],
+               funcBody = body $ integerAtomFuncLessThan True >=> boolAtomNot},
+    Function { funcName = "not",
+               funcType = [BoolAtomType, BoolAtomType],
+               funcBody = body $ \(b:_) -> boolAtomNot b },
+    Function { funcName = "int",
+               funcType = [IntegerAtomType, IntAtomType],
+               funcBody =
+                 body $ \(IntegerAtom v:_) ->
+                          if v < fromIntegral (maxBound :: Int) then
+                            
+                            pure (IntAtom (fromIntegral v))
+                          else
+                            Left InvalidIntBoundError
+             }
   ]
   where
-    body = AtomFunctionBuiltInBody
+    body = FunctionBuiltInBody
                          
 integerAtomFuncLessThan :: Bool -> [Atom] -> Either AtomFunctionError Atom
 integerAtomFuncLessThan equality (IntegerAtom i1:IntegerAtom i2:_) = pure (BoolAtom (i1 `op` i2))

--- a/src/lib/ProjectM36/AtomFunctions/Primitive.hs
+++ b/src/lib/ProjectM36/AtomFunctions/Primitive.hs
@@ -54,7 +54,7 @@ primitiveAtomFunctions = HS.fromList [
   
   ]
   where
-    body = AtomFunctionBody Nothing
+    body = AtomFunctionBuiltInBody
                          
 integerAtomFuncLessThan :: Bool -> [Atom] -> Either AtomFunctionError Atom
 integerAtomFuncLessThan equality (IntegerAtom i1:IntegerAtom i2:_) = pure (BoolAtom (i1 `op` i2))

--- a/src/lib/ProjectM36/AtomType.hs
+++ b/src/lib/ProjectM36/AtomType.hs
@@ -409,15 +409,15 @@ resolveTypeVariable (TypeVariableType tv) typ = M.singleton tv typ
 resolveTypeVariable (ConstructedAtomType _ _) (ConstructedAtomType _ actualTvMap) = actualTvMap
 resolveTypeVariable _ _ = M.empty
 
-resolveFunctionReturnValue :: AtomFunctionName -> TypeVarMap -> AtomType -> Either RelationalError AtomType
-resolveFunctionReturnValue funcName tvMap (ConstructedAtomType tCons retMap) = do
+resolveFunctionReturnValue :: FunctionName -> TypeVarMap -> AtomType -> Either RelationalError AtomType
+resolveFunctionReturnValue funcName' tvMap (ConstructedAtomType tCons retMap) = do
   let diff = M.difference retMap tvMap
   if M.null diff then
     pure (ConstructedAtomType tCons (M.intersection tvMap retMap))
     else
-    Left (AtomFunctionTypeVariableResolutionError funcName (fst (head (M.toList diff))))
-resolveFunctionReturnValue funcName tvMap (TypeVariableType tvName) = case M.lookup tvName tvMap of
-  Nothing -> Left (AtomFunctionTypeVariableResolutionError funcName tvName)
+    Left (AtomFunctionTypeVariableResolutionError funcName' (fst (head (M.toList diff))))
+resolveFunctionReturnValue funcName' tvMap (TypeVariableType tvName) = case M.lookup tvName tvMap of
+  Nothing -> Left (AtomFunctionTypeVariableResolutionError funcName' tvName)
   Just typ -> pure typ
 resolveFunctionReturnValue _ _ typ = pure typ
 

--- a/src/lib/ProjectM36/Base.hs
+++ b/src/lib/ProjectM36/Base.hs
@@ -493,16 +493,28 @@ type AtomFunctionBodyScript = StringType
 
 type AtomFunctionBodyType = [Atom] -> Either AtomFunctionError Atom
 
-data AtomFunctionBody = AtomFunctionBody (Maybe AtomFunctionBodyScript) AtomFunctionBodyType
+data AtomFunctionBody =
+  AtomFunctionScriptBody AtomFunctionBodyScript AtomFunctionBodyType
+  | AtomFunctionBuiltInBody AtomFunctionBodyType
+  | AtomFunctionObjectLoadedBody FilePath ObjectModuleName ObjectFileEntryFunctionName AtomFunctionBodyType
   deriving Generic
 
+type ObjectFileEntryFunctionName = String
+
+type ObjectFilePath = FilePath
+
+type ObjectModuleName = String
+
 instance NFData AtomFunctionBody where
-  rnf (AtomFunctionBody mScript _) = rnf mScript
+  rnf (AtomFunctionScriptBody script _) = rnf script
+  rnf (AtomFunctionBuiltInBody _) = rnf ()
+  rnf (AtomFunctionObjectLoadedBody path obj nam _) = rnf path `seq` rnf nam `seq` rnf obj
                         
 instance Show AtomFunctionBody where
-  show (AtomFunctionBody mScript _) = case mScript of
-    Just script -> show (unpack script)
-    Nothing -> "<compiled>"
+  show (AtomFunctionScriptBody script _) = show (unpack script)
+  show (AtomFunctionBuiltInBody _) = "<built-in+compiled>"
+  show (AtomFunctionObjectLoadedBody path obj nam _) =
+    "<object:\"" <> path <> "\":\"" <> obj <> "." <> nam <> "\""
 
 -- | An AtomFunction has a name, a type, and a function body to execute when called.
 data AtomFunction = AtomFunction {

--- a/src/lib/ProjectM36/Client.hs
+++ b/src/lib/ProjectM36/Client.hs
@@ -599,7 +599,8 @@ executeDatabaseContextIOExpr sessionId (InProcessConnection conf) expr = excEith
     Left err -> pure (Left err)
     Right session -> do
       graph <- readTVarIO (ipTransactionGraph conf)
-      let env = RE.DatabaseContextIOEvalEnv transId graph scriptSession
+      let env = RE.DatabaseContextIOEvalEnv transId graph scriptSession objFilesPath
+          objFilesPath = objectFilesPath <$> persistenceDirectory (ipPersistenceStrategy conf)
           transId = Sess.parentId session
           context = Sess.concreteDatabaseContext session
       res <- RE.runDatabaseContextIOEvalMonad env context (optimizeAndEvalDatabaseContextIOExpr expr)

--- a/src/lib/ProjectM36/DataTypes/ByteString.hs
+++ b/src/lib/ProjectM36/DataTypes/ByteString.hs
@@ -8,9 +8,9 @@ import qualified Data.Text.Encoding as TE
 
 bytestringAtomFunctions :: AtomFunctions
 bytestringAtomFunctions = HS.fromList [
-  AtomFunction { atomFuncName = "bytestring",
-                 atomFuncType = [TextAtomType, ByteStringAtomType],
-                 atomFuncBody = compiledAtomFunctionBody $ \(TextAtom textIn:_) -> case B64.decode (TE.encodeUtf8 textIn) of
+  Function { funcName = "bytestring",
+             funcType = [TextAtomType, ByteStringAtomType],
+             funcBody = compiledAtomFunctionBody $ \(TextAtom textIn:_) -> case B64.decode (TE.encodeUtf8 textIn) of
                    Left err -> Left (AtomFunctionBytesDecodingError err)
                    Right bs -> pure (ByteStringAtom bs) 
                }

--- a/src/lib/ProjectM36/DataTypes/DateTime.hs
+++ b/src/lib/ProjectM36/DataTypes/DateTime.hs
@@ -5,10 +5,10 @@ import qualified Data.HashSet as HS
 import Data.Time.Clock.POSIX
 
 dateTimeAtomFunctions :: AtomFunctions
-dateTimeAtomFunctions = HS.fromList [ AtomFunction {
-                                     atomFuncName = "dateTimeFromEpochSeconds",
-                                     atomFuncType = [IntegerAtomType, DateTimeAtomType],
-                                     atomFuncBody = compiledAtomFunctionBody $ \(IntegerAtom epoch:_) -> pure (DateTimeAtom (posixSecondsToUTCTime (realToFrac epoch)))
+dateTimeAtomFunctions = HS.fromList [ Function {
+                                     funcName = "dateTimeFromEpochSeconds",
+                                     funcType = [IntegerAtomType, DateTimeAtomType],
+                                     funcBody = compiledAtomFunctionBody $ \(IntegerAtom epoch:_) -> pure (DateTimeAtom (posixSecondsToUTCTime (realToFrac epoch)))
                                                                                                        }]
 
                                                  

--- a/src/lib/ProjectM36/DataTypes/Day.hs
+++ b/src/lib/ProjectM36/DataTypes/Day.hs
@@ -6,12 +6,12 @@ import Data.Time.Calendar
 
 dayAtomFunctions :: AtomFunctions
 dayAtomFunctions = HS.fromList [
-  AtomFunction { atomFuncName = "fromGregorian",
-                 atomFuncType = [IntegerAtomType, IntegerAtomType, IntegerAtomType, DayAtomType],
-                 atomFuncBody = compiledAtomFunctionBody $ \(IntegerAtom year:IntegerAtom month:IntegerAtom day:_) -> pure $ DayAtom (fromGregorian (fromIntegral year) (fromIntegral month) (fromIntegral day))
+  Function { funcName = "fromGregorian",
+                 funcType = [IntegerAtomType, IntegerAtomType, IntegerAtomType, DayAtomType],
+                 funcBody = compiledAtomFunctionBody $ \(IntegerAtom year:IntegerAtom month:IntegerAtom day:_) -> pure $ DayAtom (fromGregorian (fromIntegral year) (fromIntegral month) (fromIntegral day))
                  },
-  AtomFunction { atomFuncName = "dayEarlierThan",
-                 atomFuncType = [DayAtomType, DayAtomType, BoolAtomType],
-                 atomFuncBody = compiledAtomFunctionBody $ \(ConstructedAtom _ _ (IntAtom dayA:_):ConstructedAtom _ _ (IntAtom dayB:_):_) -> pure (BoolAtom (dayA < dayB))
+  Function { funcName = "dayEarlierThan",
+                 funcType = [DayAtomType, DayAtomType, BoolAtomType],
+                 funcBody = compiledAtomFunctionBody $ \(ConstructedAtom _ _ (IntAtom dayA:_):ConstructedAtom _ _ (IntAtom dayB:_):_) -> pure (BoolAtom (dayA < dayB))
                }
   ]

--- a/src/lib/ProjectM36/DataTypes/Interval.hs
+++ b/src/lib/ProjectM36/DataTypes/Interval.hs
@@ -92,25 +92,25 @@ intervalAtomType typ = ConstructedAtomType "Interval" (M.singleton "a" typ)
 
 intervalAtomFunctions :: AtomFunctions
 intervalAtomFunctions = HS.fromList [
-  AtomFunction { atomFuncName = "interval",
-                 atomFuncType = [TypeVariableType "a",
-                                 TypeVariableType "a",
-                                 BoolAtomType,
-                                 BoolAtomType,
-                                 intervalAtomType (TypeVariableType "a")],
-                 atomFuncBody = compiledAtomFunctionBody $ \(atom1:atom2:BoolAtom bopen:BoolAtom eopen:_) -> do
+  Function { funcName = "interval",
+             funcType = [TypeVariableType "a",
+                          TypeVariableType "a",
+                          BoolAtomType,
+                          BoolAtomType,
+                          intervalAtomType (TypeVariableType "a")],
+             funcBody = compiledAtomFunctionBody $ \(atom1:atom2:BoolAtom bopen:BoolAtom eopen:_) -> do
                    let aType = atomTypeForAtom atom1 
                    if supportsInterval aType then
                      createInterval atom1 atom2 bopen eopen
                      else
                      Left (AtomTypeDoesNotSupportIntervalError (prettyAtomType aType))
                },
-  AtomFunction {
-    atomFuncName = "interval_overlaps",
-    atomFuncType = [intervalAtomType (TypeVariableType "a"),
+  Function {
+    funcName = "interval_overlaps",
+    funcType = [intervalAtomType (TypeVariableType "a"),
                     intervalAtomType (TypeVariableType "a"),
                     BoolAtomType],
-    atomFuncBody = compiledAtomFunctionBody $ \(i1@ConstructedAtom{}:i2@ConstructedAtom{}:_) -> 
+    funcBody = compiledAtomFunctionBody $ \(i1@ConstructedAtom{}:i2@ConstructedAtom{}:_) -> 
       BoolAtom <$> intervalOverlaps i1 i2
     }]
                         

--- a/src/lib/ProjectM36/DataTypes/List.hs
+++ b/src/lib/ProjectM36/DataTypes/List.hs
@@ -34,16 +34,16 @@ listMaybeHead _ = Left AtomFunctionTypeMismatchError
 
 listAtomFunctions :: AtomFunctions
 listAtomFunctions = HS.fromList [
-  AtomFunction {
-     atomFuncName = "length",
-     atomFuncType = [listAtomType (TypeVariableType "a"), IntAtomType],
-     atomFuncBody = AtomFunctionBuiltInBody (\(listAtom:_) ->
+  Function {
+     funcName = "length",
+     funcType = [listAtomType (TypeVariableType "a"), IntAtomType],
+     funcBody = FunctionBuiltInBody (\(listAtom:_) ->
                                                  IntAtom . fromIntegral <$> listLength listAtom)
      },
-  AtomFunction {
-    atomFuncName = "maybeHead",
-    atomFuncType = [listAtomType (TypeVariableType "a"), maybeAtomType (TypeVariableType "a")],
-    atomFuncBody = AtomFunctionBuiltInBody (\(listAtom:_) -> listMaybeHead listAtom)
+  Function {
+    funcName = "maybeHead",
+    funcType = [listAtomType (TypeVariableType "a"), maybeAtomType (TypeVariableType "a")],
+    funcBody = FunctionBuiltInBody (\(listAtom:_) -> listMaybeHead listAtom)
     }
   ]
                     

--- a/src/lib/ProjectM36/DataTypes/List.hs
+++ b/src/lib/ProjectM36/DataTypes/List.hs
@@ -37,13 +37,13 @@ listAtomFunctions = HS.fromList [
   AtomFunction {
      atomFuncName = "length",
      atomFuncType = [listAtomType (TypeVariableType "a"), IntAtomType],
-     atomFuncBody = AtomFunctionBody Nothing (\(listAtom:_) ->
+     atomFuncBody = AtomFunctionBuiltInBody (\(listAtom:_) ->
                                                  IntAtom . fromIntegral <$> listLength listAtom)
      },
   AtomFunction {
     atomFuncName = "maybeHead",
     atomFuncType = [listAtomType (TypeVariableType "a"), maybeAtomType (TypeVariableType "a")],
-    atomFuncBody = AtomFunctionBody Nothing (\(listAtom:_) -> listMaybeHead listAtom)
+    atomFuncBody = AtomFunctionBuiltInBody (\(listAtom:_) -> listMaybeHead listAtom)
     }
   ]
                     

--- a/src/lib/ProjectM36/DataTypes/Maybe.hs
+++ b/src/lib/ProjectM36/DataTypes/Maybe.hs
@@ -19,12 +19,12 @@ maybeAtomFunctions = HS.fromList [
   AtomFunction {
      atomFuncName ="isJust",
      atomFuncType = [maybeAtomType (TypeVariableType "a"), BoolAtomType],
-     atomFuncBody = AtomFunctionBody Nothing $ \(ConstructedAtom dConsName _ _:_) -> pure $ BoolAtom (dConsName /= "Nothing")
+     atomFuncBody = AtomFunctionBuiltInBody $ \(ConstructedAtom dConsName _ _:_) -> pure $ BoolAtom (dConsName /= "Nothing")
      },
   AtomFunction {
      atomFuncName = "fromMaybe",
      atomFuncType = [TypeVariableType "a", maybeAtomType (TypeVariableType "a"), TypeVariableType "a"],
-     atomFuncBody = AtomFunctionBody Nothing $ \(defaultAtom:ConstructedAtom dConsName _ (atomVal:_):_) -> if atomTypeForAtom defaultAtom /= atomTypeForAtom atomVal then Left AtomFunctionTypeMismatchError else if dConsName == "Nothing" then pure defaultAtom else pure atomVal
+     atomFuncBody = AtomFunctionBuiltInBody $ \(defaultAtom:ConstructedAtom dConsName _ (atomVal:_):_) -> if atomTypeForAtom defaultAtom /= atomTypeForAtom atomVal then Left AtomFunctionTypeMismatchError else if dConsName == "Nothing" then pure defaultAtom else pure atomVal
      }
   ]
 

--- a/src/lib/ProjectM36/DataTypes/Maybe.hs
+++ b/src/lib/ProjectM36/DataTypes/Maybe.hs
@@ -16,15 +16,15 @@ maybeTypeConstructorMapping = [(ADTypeConstructorDef "Maybe" ["a"],
 
 maybeAtomFunctions :: AtomFunctions
 maybeAtomFunctions = HS.fromList [
-  AtomFunction {
-     atomFuncName ="isJust",
-     atomFuncType = [maybeAtomType (TypeVariableType "a"), BoolAtomType],
-     atomFuncBody = AtomFunctionBuiltInBody $ \(ConstructedAtom dConsName _ _:_) -> pure $ BoolAtom (dConsName /= "Nothing")
+  Function {
+     funcName ="isJust",
+     funcType = [maybeAtomType (TypeVariableType "a"), BoolAtomType],
+     funcBody = FunctionBuiltInBody $ \(ConstructedAtom dConsName _ _:_) -> pure $ BoolAtom (dConsName /= "Nothing")
      },
-  AtomFunction {
-     atomFuncName = "fromMaybe",
-     atomFuncType = [TypeVariableType "a", maybeAtomType (TypeVariableType "a"), TypeVariableType "a"],
-     atomFuncBody = AtomFunctionBuiltInBody $ \(defaultAtom:ConstructedAtom dConsName _ (atomVal:_):_) -> if atomTypeForAtom defaultAtom /= atomTypeForAtom atomVal then Left AtomFunctionTypeMismatchError else if dConsName == "Nothing" then pure defaultAtom else pure atomVal
+  Function {
+     funcName = "fromMaybe",
+     funcType = [TypeVariableType "a", maybeAtomType (TypeVariableType "a"), TypeVariableType "a"],
+     funcBody = FunctionBuiltInBody $ \(defaultAtom:ConstructedAtom dConsName _ (atomVal:_):_) -> if atomTypeForAtom defaultAtom /= atomTypeForAtom atomVal then Left AtomFunctionTypeMismatchError else if dConsName == "Nothing" then pure defaultAtom else pure atomVal
      }
   ]
 

--- a/src/lib/ProjectM36/DataTypes/NonEmptyList.hs
+++ b/src/lib/ProjectM36/DataTypes/NonEmptyList.hs
@@ -42,12 +42,12 @@ nonEmptyListAtomFunctions = HS.fromList [
   AtomFunction {
      atomFuncName = "nonEmptyListLength",
      atomFuncType = [nonEmptyListAtomType (TypeVariableType "a"), IntAtomType],
-     atomFuncBody = AtomFunctionBody Nothing (\(nonEmptyListAtom:_) ->
+     atomFuncBody = AtomFunctionBuiltInBody (\(nonEmptyListAtom:_) ->
                                                  IntAtom . fromIntegral <$> nonEmptyListLength nonEmptyListAtom)
      },
   AtomFunction {
     atomFuncName = "nonEmptyListHead",
     atomFuncType = [nonEmptyListAtomType (TypeVariableType "a"), TypeVariableType "a"],
-    atomFuncBody = AtomFunctionBody Nothing (\(nonEmptyListAtom:_) -> nonEmptyListHead nonEmptyListAtom)
+    atomFuncBody = AtomFunctionBuiltInBody (\(nonEmptyListAtom:_) -> nonEmptyListHead nonEmptyListAtom)
     }
   ]

--- a/src/lib/ProjectM36/DataTypes/NonEmptyList.hs
+++ b/src/lib/ProjectM36/DataTypes/NonEmptyList.hs
@@ -39,15 +39,15 @@ listMaybeHead _ = Left AtomFunctionTypeMismatchError
 
 nonEmptyListAtomFunctions :: AtomFunctions
 nonEmptyListAtomFunctions = HS.fromList [
-  AtomFunction {
-     atomFuncName = "nonEmptyListLength",
-     atomFuncType = [nonEmptyListAtomType (TypeVariableType "a"), IntAtomType],
-     atomFuncBody = AtomFunctionBuiltInBody (\(nonEmptyListAtom:_) ->
+  Function {
+     funcName = "nonEmptyListLength",
+     funcType = [nonEmptyListAtomType (TypeVariableType "a"), IntAtomType],
+     funcBody = FunctionBuiltInBody (\(nonEmptyListAtom:_) ->
                                                  IntAtom . fromIntegral <$> nonEmptyListLength nonEmptyListAtom)
      },
-  AtomFunction {
-    atomFuncName = "nonEmptyListHead",
-    atomFuncType = [nonEmptyListAtomType (TypeVariableType "a"), TypeVariableType "a"],
-    atomFuncBody = AtomFunctionBuiltInBody (\(nonEmptyListAtom:_) -> nonEmptyListHead nonEmptyListAtom)
+  Function {
+    funcName = "nonEmptyListHead",
+    funcType = [nonEmptyListAtomType (TypeVariableType "a"), TypeVariableType "a"],
+    funcBody = FunctionBuiltInBody (\(nonEmptyListAtom:_) -> nonEmptyListHead nonEmptyListAtom)
     }
   ]

--- a/src/lib/ProjectM36/DatabaseContext.hs
+++ b/src/lib/ProjectM36/DatabaseContext.hs
@@ -7,9 +7,9 @@ import ProjectM36.DataTypes.Basic
 import ProjectM36.AtomFunctions.Basic
 import ProjectM36.Relation
 import qualified Data.ByteString.Lazy as BL
-import ProjectM36.AtomFunction as AF
-import ProjectM36.DatabaseContextFunction as DBCF
+import ProjectM36.DatabaseContextFunction
 import Codec.Winery
+import ProjectM36.Function as F
 
 empty :: DatabaseContext
 empty = DatabaseContext { inclusionDependencies = M.empty, 
@@ -48,7 +48,7 @@ hashBytes ctx = BL.fromChunks [incDeps, rvs, nots, tConsMap] <> atomFs <> dbcFs
   where
     incDeps = serialise (inclusionDependencies ctx)
     rvs = serialise (relationVariables ctx)
-    atomFs = HS.foldr (mappend . AF.hashBytes) mempty (atomFunctions ctx)
-    dbcFs = HS.foldr (mappend . DBCF.hashBytes) mempty (dbcFunctions ctx)
+    atomFs = HS.foldr (mappend . F.hashBytes) mempty (atomFunctions ctx)
+    dbcFs = HS.foldr (mappend . F.hashBytes) mempty (dbcFunctions ctx)
     nots = serialise (notifications ctx)
     tConsMap = serialise (typeConstructorMapping ctx)

--- a/src/lib/ProjectM36/DatabaseContextFunction.hs
+++ b/src/lib/ProjectM36/DatabaseContextFunction.hs
@@ -7,40 +7,42 @@ import ProjectM36.Serialise.Base ()
 import ProjectM36.Attribute as A
 import ProjectM36.Relation
 import ProjectM36.AtomType
+import ProjectM36.Function
 import qualified Data.HashSet as HS
 import qualified Data.Map as M
 import ProjectM36.ScriptSession
 import qualified Data.Text as T
-import qualified Data.ByteString.Lazy as BL
-import Codec.Winery
+import Data.Maybe (isJust)
 
-emptyDatabaseContextFunction :: DatabaseContextFunctionName -> DatabaseContextFunction
-emptyDatabaseContextFunction name = DatabaseContextFunction { 
-  dbcFuncName = name,
-  dbcFuncType = [],
-  dbcFuncBody = DatabaseContextFunctionBody Nothing (\_ ctx -> pure ctx)
+emptyDatabaseContextFunction :: FunctionName -> DatabaseContextFunction
+emptyDatabaseContextFunction name = Function { 
+  funcName = name,
+  funcType = [],
+  funcBody = FunctionBuiltInBody (\_ ctx -> pure ctx)
   }
 
-databaseContextFunctionForName :: DatabaseContextFunctionName -> DatabaseContextFunctions -> Either RelationalError DatabaseContextFunction
-databaseContextFunctionForName funcName funcs = if HS.null foundFunc then
-                                                   Left $ NoSuchFunctionError funcName
+databaseContextFunctionForName :: FunctionName -> DatabaseContextFunctions -> Either RelationalError DatabaseContextFunction
+databaseContextFunctionForName funcName' funcs = if HS.null foundFunc then
+                                                   Left $ NoSuchFunctionError funcName'
                                                 else
                                                   Right (head (HS.toList foundFunc))
   where
-    foundFunc = HS.filter (\(DatabaseContextFunction name _ _) -> name == funcName) funcs
+    foundFunc = HS.filter (\f -> funcName f == funcName') funcs
 
 evalDatabaseContextFunction :: DatabaseContextFunction -> [Atom] -> DatabaseContext -> Either RelationalError DatabaseContext
-evalDatabaseContextFunction func args ctx = case dbcFuncBody func of
-  (DatabaseContextFunctionBody _ f) -> case f args ctx of
+evalDatabaseContextFunction func args ctx =
+  case f args ctx of
     Left err -> Left (DatabaseContextFunctionUserError err)
     Right c -> pure c
-  
+  where
+   f = function (funcBody func)
+   
 basicDatabaseContextFunctions :: DatabaseContextFunctions
 basicDatabaseContextFunctions = HS.fromList [
-  DatabaseContextFunction { dbcFuncName = "deleteAll",
-                            dbcFuncType = [],
-                            dbcFuncBody = DatabaseContextFunctionBody Nothing (\_ ctx -> pure $ ctx { relationVariables = M.empty })
-                          }
+  Function { funcName = "deleteAll",
+             funcType = [],
+             funcBody = FunctionBuiltInBody (\_ ctx -> pure $ ctx { relationVariables = M.empty })
+           }
   ]
                                 
 --the precompiled functions are special because they cannot be serialized. Their names are therefore used in perpetuity so that the functions can be "serialized" (by name).
@@ -48,21 +50,15 @@ precompiledDatabaseContextFunctions :: DatabaseContextFunctions
 precompiledDatabaseContextFunctions = HS.filter (not . isScriptedDatabaseContextFunction) basicDatabaseContextFunctions
                                 
 isScriptedDatabaseContextFunction :: DatabaseContextFunction -> Bool
-isScriptedDatabaseContextFunction func = case dbcFuncBody func of
-  DatabaseContextFunctionBody (Just _) _ -> True
-  DatabaseContextFunctionBody Nothing _ -> False
-  
-databaseContextFunctionScript :: DatabaseContextFunction -> Maybe DatabaseContextFunctionBodyScript
-databaseContextFunctionScript func = case dbcFuncBody func of
-  DatabaseContextFunctionBody script _ -> script
+isScriptedDatabaseContextFunction func = isJust (functionScript func)
   
 databaseContextFunctionReturnType :: TypeConstructor -> TypeConstructor
 databaseContextFunctionReturnType tCons = ADTypeConstructor "Either" [
   ADTypeConstructor "DatabaseContextFunctionError" [],
   tCons]
                                           
-createScriptedDatabaseContextFunction :: DatabaseContextFunctionName -> [TypeConstructor] -> TypeConstructor -> DatabaseContextFunctionBodyScript -> DatabaseContextIOExpr
-createScriptedDatabaseContextFunction funcName argsIn retArg = AddDatabaseContextFunction funcName (argsIn ++ [databaseContextFunctionReturnType retArg])
+createScriptedDatabaseContextFunction :: FunctionName -> [TypeConstructor] -> TypeConstructor -> FunctionBodyScript -> DatabaseContextIOExpr
+createScriptedDatabaseContextFunction funcName' argsIn retArg = AddDatabaseContextFunction funcName' (argsIn ++ [databaseContextFunctionReturnType retArg])
 
 loadDatabaseContextFunctions :: ModName -> FuncName -> FilePath -> IO (Either LoadSymbolError [DatabaseContextFunction])
 #ifdef PM36_HASKELL_SCRIPTING
@@ -77,15 +73,7 @@ databaseContextFunctionsAsRelation dbcFuncs = mkRelationFromList attrs tups
     attrs = A.attributesFromList [Attribute "name" TextAtomType,
                                   Attribute "arguments" TextAtomType]
     tups = map dbcFuncToTuple (HS.toList dbcFuncs)
-    dbcFuncToTuple func = [TextAtom (dbcFuncName func),
-                           TextAtom (dbcTextType (dbcFuncType func))]
+    dbcFuncToTuple func = [TextAtom (funcName func),
+                           TextAtom (dbcTextType (funcType func))]
     dbcTextType typ = T.intercalate " -> " (map prettyAtomType typ ++ ["DatabaseContext", "DatabaseContext"])
 
--- for merkle hash                       
-hashBytes :: DatabaseContextFunction -> BL.ByteString
-hashBytes func = BL.fromChunks [fname, ftype, fbody]
-  where
-    fname = serialise (dbcFuncName func)
-    ftype = serialise (dbcFuncType func)
-    fbody = case dbcFuncBody func of
-      DatabaseContextFunctionBody mBody _ -> serialise mBody

--- a/src/lib/ProjectM36/DatabaseContextFunction.hs
+++ b/src/lib/ProjectM36/DatabaseContextFunction.hs
@@ -14,6 +14,9 @@ import ProjectM36.ScriptSession
 import qualified Data.Text as T
 import Data.Maybe (isJust)
 
+externalDatabaseContextFunction :: DatabaseContextFunctionBodyType -> DatabaseContextFunctionBody
+externalDatabaseContextFunction = FunctionBuiltInBody
+
 emptyDatabaseContextFunction :: FunctionName -> DatabaseContextFunction
 emptyDatabaseContextFunction name = Function { 
   funcName = name,
@@ -59,13 +62,6 @@ databaseContextFunctionReturnType tCons = ADTypeConstructor "Either" [
                                           
 createScriptedDatabaseContextFunction :: FunctionName -> [TypeConstructor] -> TypeConstructor -> FunctionBodyScript -> DatabaseContextIOExpr
 createScriptedDatabaseContextFunction funcName' argsIn retArg = AddDatabaseContextFunction funcName' (argsIn ++ [databaseContextFunctionReturnType retArg])
-
-loadDatabaseContextFunctions :: ModName -> FuncName -> FilePath -> IO (Either LoadSymbolError [DatabaseContextFunction])
-#ifdef PM36_HASKELL_SCRIPTING
-loadDatabaseContextFunctions = loadFunction LoadAutoObjectFile
-#else
-loadDatabaseContextFunctions _ _ _ = pure (Left LoadSymbolError)
-#endif
 
 databaseContextFunctionsAsRelation :: DatabaseContextFunctions -> Either RelationalError Relation
 databaseContextFunctionsAsRelation dbcFuncs = mkRelationFromList attrs tups

--- a/src/lib/ProjectM36/DatabaseContextFunction.hs
+++ b/src/lib/ProjectM36/DatabaseContextFunction.hs
@@ -10,7 +10,6 @@ import ProjectM36.AtomType
 import ProjectM36.Function
 import qualified Data.HashSet as HS
 import qualified Data.Map as M
-import ProjectM36.ScriptSession
 import qualified Data.Text as T
 import Data.Maybe (isJust)
 

--- a/src/lib/ProjectM36/DatabaseContextFunction.hs
+++ b/src/lib/ProjectM36/DatabaseContextFunction.hs
@@ -66,7 +66,7 @@ createScriptedDatabaseContextFunction funcName argsIn retArg = AddDatabaseContex
 
 loadDatabaseContextFunctions :: ModName -> FuncName -> FilePath -> IO (Either LoadSymbolError [DatabaseContextFunction])
 #ifdef PM36_HASKELL_SCRIPTING
-loadDatabaseContextFunctions = loadFunction
+loadDatabaseContextFunctions = loadFunction LoadAutoObjectFile
 #else
 loadDatabaseContextFunctions _ _ _ = pure (Left LoadSymbolError)
 #endif

--- a/src/lib/ProjectM36/Error.hs
+++ b/src/lib/ProjectM36/Error.hs
@@ -45,7 +45,7 @@ data RelationalError = NoSuchAttributeNamesError (S.Set AttributeName)
                      | NoSuchSessionError TransactionId
                      | FailedToFindTransactionError TransactionId
                      | TransactionIdInUseError TransactionId
-                     | NoSuchFunctionError AtomFunctionName
+                     | NoSuchFunctionError FunctionName
                      | NoSuchTypeConstructorName TypeConstructorName
                      | TypeConstructorAtomTypeMismatch TypeConstructorName AtomType
                      | AtomTypeMismatchError AtomType AtomType
@@ -57,14 +57,14 @@ data RelationalError = NoSuchAttributeNamesError (S.Set AttributeName)
                      | TypeConstructorTypeVarMissing TypeVarName
                      | TypeConstructorTypeVarsTypesMismatch TypeConstructorName TypeVarMap TypeVarMap
                      | DataConstructorTypeVarsMismatch DataConstructorName TypeVarMap TypeVarMap
-                     | AtomFunctionTypeVariableResolutionError AtomFunctionName TypeVarName
+                     | AtomFunctionTypeVariableResolutionError FunctionName TypeVarName
                      | AtomFunctionTypeVariableMismatch TypeVarName AtomType AtomType
                      | AtomTypeNameInUseError AtomTypeName
                      | IncompletelyDefinedAtomTypeWithConstructorError
                      | AtomTypeNameNotInUseError AtomTypeName
                      | AttributeNotSortableError Attribute
-                     | FunctionNameInUseError AtomFunctionName
-                     | FunctionNameNotInUseError AtomFunctionName
+                     | FunctionNameInUseError FunctionName
+                     | FunctionNameNotInUseError FunctionName
                      | EmptyCommitError
                      | FunctionArgumentCountMismatchError Int Int
                      | ConstructedAtomArgumentCountMismatchError Int Int
@@ -75,9 +75,9 @@ data RelationalError = NoSuchAttributeNamesError (S.Set AttributeName)
                      | AtomOperatorNotSupported T.Text --used by persistent driver
                      | EmptyTuplesError -- used by persistent driver
                      | AtomTypeCountError [AtomType] [AtomType]
-                     | AtomFunctionTypeError AtomFunctionName Int AtomType AtomType --arg number
+                     | AtomFunctionTypeError FunctionName Int AtomType AtomType --arg number
                      | AtomFunctionUserError AtomFunctionError
-                     | PrecompiledFunctionRemoveError AtomFunctionName -- pre-compiled atom functions cannot be serialized, so they cannot change over time- they are referred to in perpetuity
+                     | PrecompiledFunctionRemoveError FunctionName -- pre-compiled atom functions cannot be serialized, so they cannot change over time- they are referred to in perpetuity
                      | RelationValuedAttributesNotSupportedError [AttributeName]
                      | NotificationNameInUseError NotificationName
                      | NotificationNameNotInUseError NotificationName

--- a/src/lib/ProjectM36/Error.hs
+++ b/src/lib/ProjectM36/Error.hs
@@ -87,6 +87,7 @@ data RelationalError = NoSuchAttributeNamesError (S.Set AttributeName)
                      | MergeTransactionError MergeError
                      | ScriptError ScriptCompilationError
                      | LoadFunctionError
+                     | SecurityLoadFunctionError
                      | DatabaseContextFunctionUserError DatabaseContextFunctionError
                      | DatabaseLoadError PersistenceError
                        

--- a/src/lib/ProjectM36/Function.hs
+++ b/src/lib/ProjectM36/Function.hs
@@ -1,9 +1,12 @@
 -- | Module for functionality common between the various Function types (AtomFunction, DatabaseContextFunction).
 module ProjectM36.Function where
 import ProjectM36.Base
+import ProjectM36.Error
 import ProjectM36.Serialise.Base ()
+import ProjectM36.ScriptSession
 import qualified Data.ByteString.Lazy as BL
 import Codec.Winery
+import qualified Data.HashSet as HS
 
 -- for merkle hash                       
 hashBytes :: Function a -> BL.ByteString
@@ -27,3 +30,42 @@ functionScript :: Function a -> Maybe FunctionBodyScript
 functionScript func = case funcBody func of
   FunctionScriptBody script _ -> Just script
   _ -> Nothing
+
+-- | Change atom function definition to reference proper object file source. Useful when moving the object file into the database directory.
+processObjectLoadedFunctionBody :: ObjectModuleName -> ObjectFileEntryFunctionName -> FilePath -> FunctionBody a -> FunctionBody a
+processObjectLoadedFunctionBody modName fentry objPath body =
+  FunctionObjectLoadedBody objPath modName fentry f
+  where
+    f = function body
+
+processObjectLoadedFunctions :: Functor f => ObjectModuleName -> ObjectFileEntryFunctionName -> FilePath -> f (Function a) -> f (Function a)
+processObjectLoadedFunctions modName entryName path =
+  fmap (\f -> f { funcBody = processObjectLoadedFunctionBody modName entryName path (funcBody f) } )
+
+loadFunctions :: ModName -> FuncName -> Maybe FilePath -> FilePath -> IO (Either LoadSymbolError [Function a])
+#ifdef PM36_HASKELL_SCRIPTING
+loadFunctions modName funcName' mModDir objPath =
+  case mModDir of
+    Just modDir -> do
+      eNewFs <- loadFunctionFromDirectory LoadAutoObjectFile modName funcName' modDir objPath
+      case eNewFs of
+        Left err -> pure (Left err)
+        Right newFs ->
+          pure (Right (processFuncs newFs))
+    Nothing -> do
+      loadFunction LoadAutoObjectFile modName funcName' objPath
+ where
+   --functions inside object files probably won't have the right function body metadata
+   processFuncs = map processor
+   processor newF = newF { funcBody = processObjectLoadedFunctionBody modName funcName' objPath (funcBody newF)}
+#else
+loadFunctions _ _ _ _ = pure (Left LoadSymbolError)
+#endif
+
+functionForName :: FunctionName -> HS.HashSet (Function a) -> Either RelationalError (Function a)
+functionForName funcName' funcSet = if HS.null foundFunc then
+                                         Left $ NoSuchFunctionError funcName'
+                                        else
+                                         Right $ head $ HS.toList foundFunc
+  where
+    foundFunc = HS.filter (\f -> funcName f == funcName') funcSet

--- a/src/lib/ProjectM36/Function.hs
+++ b/src/lib/ProjectM36/Function.hs
@@ -1,0 +1,29 @@
+-- | Module for functionality common between the various Function types (AtomFunction, DatabaseContextFunction).
+module ProjectM36.Function where
+import ProjectM36.Base
+import ProjectM36.Serialise.Base ()
+import qualified Data.ByteString.Lazy as BL
+import Codec.Winery
+
+-- for merkle hash                       
+hashBytes :: Function a -> BL.ByteString
+hashBytes func = BL.fromChunks [fname, ftype, fbody]
+  where
+    fname = serialise (funcName func)
+    ftype = serialise (funcType func)
+    fbody = case funcBody func of
+      FunctionScriptBody s _ -> serialise s
+      FunctionBuiltInBody _ -> serialise ()
+      FunctionObjectLoadedBody a b c _ -> serialise (a,b,c)
+
+-- | Return the underlying function to run the Function.
+function :: FunctionBody a -> a
+function (FunctionScriptBody _ f) = f
+function (FunctionBuiltInBody f) = f
+function (FunctionObjectLoadedBody _ _ _ f) = f
+
+-- | Return the text-based Haskell script, if applicable.
+functionScript :: Function a -> Maybe FunctionBodyScript
+functionScript func = case funcBody func of
+  FunctionScriptBody script _ -> Just script
+  _ -> Nothing

--- a/src/lib/ProjectM36/NormalizeExpr.hs
+++ b/src/lib/ProjectM36/NormalizeExpr.hs
@@ -75,8 +75,8 @@ processDatabaseContextExpr expr =
     RemoveTypeConstructor tyName -> pure (RemoveTypeConstructor tyName)
 
     RemoveAtomFunction aFuncName -> pure (RemoveAtomFunction aFuncName)
-    RemoveDatabaseContextFunction funcName -> pure (RemoveDatabaseContextFunction funcName)
-    ExecuteDatabaseContextFunction funcName atomExprs -> ExecuteDatabaseContextFunction funcName <$> mapM processAtomExpr atomExprs
+    RemoveDatabaseContextFunction funcName' -> pure (RemoveDatabaseContextFunction funcName')
+    ExecuteDatabaseContextFunction funcName' atomExprs -> ExecuteDatabaseContextFunction funcName' <$> mapM processAtomExpr atomExprs
     MultipleExpr exprs -> MultipleExpr <$> mapM processDatabaseContextExpr exprs
 
 processDatabaseContextIOExpr :: DatabaseContextIOExpr -> ProcessExprM GraphRefDatabaseContextIOExpr

--- a/src/lib/ProjectM36/Relation/Parse/CSV.hs
+++ b/src/lib/ProjectM36/Relation/Parse/CSV.hs
@@ -142,11 +142,11 @@ takeToEndOfData = APT.takeWhile (APT.notInClass ",)]")
   
 parens :: APT.Parser a -> APT.Parser a  
 parens p = do
-  APT.char '('
+  void (APT.char '(')
   APT.skipSpace
   v <- p
   APT.skipSpace
-  APT.char ')'
+  void (APT.char ')')
   pure v
   
 quotedString :: APT.Parser T.Text

--- a/src/lib/ProjectM36/Shortcuts.hs
+++ b/src/lib/ProjectM36/Shortcuts.hs
@@ -175,7 +175,7 @@ instance Convertible RelVarName RelationalExpr where
 
 -- works in RestrictedPredicateExpr and AttributeExtendTupleExpr 
 -- usage: f "gte" [1]
-f :: Convertible a AtomExpr => AtomFunctionName -> [a] -> AtomExpr
+f :: Convertible a AtomExpr => FunctionName -> [a] -> AtomExpr
 f n as' = FunctionAtomExpr n (map convert as') ()
 
 -- DatabaseContextExpr

--- a/src/lib/ProjectM36/TransGraphRelationalExpression.hs
+++ b/src/lib/ProjectM36/TransGraphRelationalExpression.hs
@@ -122,8 +122,8 @@ processTransGraphTupleExpr (TupleExpr attrMap) = do
 processTransGraphAtomExpr :: TransGraphAtomExpr -> TransGraphEvalMonad GraphRefAtomExpr
 processTransGraphAtomExpr (AttributeAtomExpr aname) = pure $ AttributeAtomExpr aname
 processTransGraphAtomExpr (NakedAtomExpr atom) = pure $ NakedAtomExpr atom
-processTransGraphAtomExpr (FunctionAtomExpr funcName args tLookup) =
-  FunctionAtomExpr funcName <$> mapM processTransGraphAtomExpr args <*> findTransId tLookup
+processTransGraphAtomExpr (FunctionAtomExpr funcName' args tLookup) =
+  FunctionAtomExpr funcName' <$> mapM processTransGraphAtomExpr args <*> findTransId tLookup
 processTransGraphAtomExpr (RelationAtomExpr expr) =
   RelationAtomExpr <$> processTransGraphRelationalExpr expr
 processTransGraphAtomExpr (ConstructedAtomExpr dConsName args tLookup) =

--- a/src/lib/ProjectM36/Transaction/Persist.hs
+++ b/src/lib/ProjectM36/Transaction/Persist.hs
@@ -140,7 +140,7 @@ loadAtomFunc precompiledFuncs _mScriptSession funcName _funcType mFuncScript = c
             Left err -> throwIO err
             Right compiledScript -> pure AtomFunction { atomFuncName = funcName,
                                                         atomFuncType = _funcType,
-                                                        atomFuncBody = AtomFunctionBody (Just _funcScript) compiledScript }
+                                                        atomFuncBody = AtomFunctionScriptBody _funcScript compiledScript }
 #else
       error "Haskell scripting is disabled"
 #endif                                    
@@ -174,7 +174,7 @@ readAtomFunc transDir funcName mScriptSession precompiledFuncs = do
             Left err -> throwIO err
             Right compiledScript -> pure AtomFunction { atomFuncName = funcName,
                                                          atomFuncType = funcType,
-                                                         atomFuncBody = AtomFunctionBody (Just funcScript) compiledScript }
+                                                         atomFuncBody = AtomFunctionScriptBody funcScript compiledScript }
 #endif
 
 

--- a/src/lib/ProjectM36/Transaction/Persist.hs
+++ b/src/lib/ProjectM36/Transaction/Persist.hs
@@ -107,7 +107,15 @@ readRelVars transDir =
 
 writeAtomFuncs :: DiskSync -> FilePath -> AtomFunctions -> IO ()
 writeAtomFuncs sync transDir funcs = do
-  let atomFuncPath = atomFuncsPath transDir 
+  --copy in object file, if necessary, and alter AtomFunctionBody to point to database-specific version of object file
+  let atomFuncPath = atomFuncsPath transDir
+      unresolvedObjectFuncs =
+        filter (\af ->
+                  case atomFuncBody af of
+                    AtomFunctionObjectLoadedBody objPath ->
+                      --if a hash of the object file is not in our own obj directory, the we need to copy it
+                    _ -> False
+                   ) func
   writeBSFileSync sync atomFuncPath (serialise $ map (\f -> (atomFuncType f, atomFuncName f, atomFunctionScript f)) (HS.toList funcs))
 
 --all the atom functions are in one file

--- a/src/lib/ProjectM36/Transaction/Persist.hs
+++ b/src/lib/ProjectM36/Transaction/Persist.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+#ifdef PM36_HASKELL_SCRIPTING
+{-# LANGUAGE TypeApplications #-}
+#endif
 module ProjectM36.Transaction.Persist where
 import ProjectM36.Base
 import ProjectM36.Error

--- a/src/lib/ProjectM36/TransactionGraph/Persist.hs
+++ b/src/lib/ProjectM36/TransactionGraph/Persist.hs
@@ -43,7 +43,7 @@ Persistence requires a POSIX-compliant, journaled-metadata filesystem.
 -}
 
 expectedVersion :: Int
-expectedVersion = 5
+expectedVersion = 6
 
 transactionLogFileName :: FilePath 
 transactionLogFileName = "m36v" ++ show expectedVersion
@@ -98,9 +98,12 @@ bootstrapDatabaseDir sync dbdir bootstrapGraph = do
   createDirectory dbdir
   locker <- openLockFile (lockFilePath dbdir)
   let allTransIds = map transactionId (S.toList (transactionsForGraph bootstrapGraph))
+  createDirectoryIfMissing False (ProjectM36.TransactionGraph.Persist.objectFilesPath dbdir)
   digest  <- bracket_ (lockFile locker WriteLock) (unlockFile locker) (transactionGraphPersist sync dbdir allTransIds bootstrapGraph)
   pure (locker, digest)
-  
+
+objectFilesPath :: FilePath -> FilePath
+objectFilesPath dbdir = dbdir </> "compiled_modules"
 {- 
 incrementally updates an existing database directory
 --algorithm: 

--- a/test/TutorialD/Interpreter/Import/ImportTest.hs
+++ b/test/TutorialD/Interpreter/Import/ImportTest.hs
@@ -7,7 +7,6 @@ import System.IO.Temp
 import System.FilePath
 import qualified Data.Map as M
 import System.IO
-import System.Directory
 import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as TE
 import Text.URI hiding (makeAbsolute)


### PR DESCRIPTION
This patch enables loading atom and database context functions from the persistent storage database directory under the "compiled_modules" directory. The expected use-case requires that the database owner copy the object file into that directory and then load it. Subsequent restarts of the server will also load the module from the same location. If a user attempts to load an object file from elsewhere, the load should fail with a security error.

@farzadbekran, would you be willing to test this branch? The object loading code can be tricky and I want to make sure nothing is specific to my environment.

resolves #312 