### PR TITLE
load GraphRefRelVars instead of real expressions

### DIFF
--- a/src/lib/ProjectM36/Client.hs
+++ b/src/lib/ProjectM36/Client.hs
@@ -383,7 +383,7 @@ createSessionAtCommit_ commitId newSessionId (InProcessConnection conf) = do
     case RE.transactionForId commitId graph of
         Left err -> pure (Left err)
         Right transaction -> do
-            let freshDiscon = DisconnectedTransaction commitId (Trans.schemas transaction) False
+            let freshDiscon = DisconnectedTransaction commitId (Discon.loadGraphRefRelVarsOnly commitId (Trans.schemas transaction)) False
             keyDuplication <- StmMap.lookup newSessionId sessions
             case keyDuplication of
                 Just _ -> pure $ Left (SessionIdInUseError newSessionId)

--- a/src/lib/ProjectM36/DisconnectedTransaction.hs
+++ b/src/lib/ProjectM36/DisconnectedTransaction.hs
@@ -1,11 +1,20 @@
 module ProjectM36.DisconnectedTransaction where
 import ProjectM36.Base
+import Data.Map
 
 concreteDatabaseContext :: DisconnectedTransaction -> DatabaseContext
 concreteDatabaseContext (DisconnectedTransaction _ (Schemas context _) _) = context
 
 schemas :: DisconnectedTransaction -> Schemas
 schemas (DisconnectedTransaction _ s _) = s
+
+loadGraphRefRelVarsOnly :: TransactionId -> Schemas -> Schemas
+loadGraphRefRelVarsOnly commitId (Schemas ctx@(DatabaseContext _ rv _ _ _ _) subschemas) = 
+  let f k _ = RelationVariable k (TransactionMarker commitId)
+      ctx' = ctx { relationVariables = mapWithKey f rv}
+  in Schemas ctx' subschemas
+
+
 
 parentId :: DisconnectedTransaction -> TransactionId
 parentId (DisconnectedTransaction pid _ _) = pid


### PR DESCRIPTION
This time, If I `createarbitraryrelation a {a Int} 1000000-1000000` and `:commit` twice, I have only one large transaction in disk.

The space usage should grow much slower.

