### PR TITLE
Adding compatibility for GHC 9.6, GHC 9.8, and GHC 9.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
         ghc_version:
           - 9.2
           - 9.4
+          - 9.6
+          - 9.8
+          - 9.10
         include:
           - os: macos-latest
             ghc_version: 9.2

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,21 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.8.2
+            compilerKind: ghc
+            compilerVersion: 9.8.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.6
+            compilerKind: ghc
+            compilerVersion: 9.6.6
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.8
             compilerKind: ghc
             compilerVersion: 9.4.8

--- a/Changelog.markdown
+++ b/Changelog.markdown
@@ -1,3 +1,8 @@
+# 2024-87-12 (v1.1.0)
+
+* add support for GHC 9.6, GHC 9.8, and GHC 9.10
+* clean up compiler warnings
+
 # 2024-07-27 (v1.0.2)
 
 * upgrade to streamly 0.10.1
@@ -17,33 +22,33 @@
 
 * revert to using streamly 0.9.0 due to over-the-wire corruption bug in 0.10.0
 * fixed toAtom/fromAtom for NonEmpty lists (#363)
-	
+
 # 2023-12-30 (v0.9.8)
 
 * fix notification serialization in transaction (#362)
 * require minimum GHC 9.2 (dropping GHC 8.10 and GHC 9.0)
 * add support for GHC 9.4
-	
+
 # 2023-07-18 (v0.9.7)
 
 * fix critical bug resulting in empty results from cross joins
-	
+
 # 2022-11-05 (v0.9.6)
 
 * fix tuple context passed down to extended expressions
 * add ddl hash- useful for validating that the client supports the current schema
 * add registered queries- useful for constraining what DDL can be applied to the database so as not to break client applications
 * reduce memory usage during Merkle hashing by an order of magnitude by using strict serialization and hashing
-	
+
 # 2022-08-19 (v0.9.5)
-  
+
 * removed necessity for caret "^" when using boolean atom expressions in restriction predicates
 * `True` and `False` are now value constructors for `Bool` atom values (previously `t` and `f); changed for better discoverability by Haskell developers
 * add `Scientific` data type for arbitrary-precision values (backed by Data.Scientific)
 * add support for GHC 9.0 and GHC 9.2
 * drop support for GHC < 8.10.7
 * fix relational equality when the relation includes a nested relation
-	
+
 # 2021-12-05 (v0.9.4)
 
 * fix bug which [caused tuple storage to be duplicated unnecessarily](https://github.com/agentm/project-m36/pull/328)
@@ -54,11 +59,11 @@
 * fix constraint checking after undefining a relation variable
 * optionally allow TLS and client certificate authentication in Project:M36 server
 * require GHC >=8.8
-	
+
 # 2021-04-01 (v0.9.3)
 
-* add new ":importtutd <URI> <SHA256 hash>" feature to import TutorialD from a local file or a HTTP/HTTPS URI	
-	
+* add new ":importtutd <URI> <SHA256 hash>" feature to import TutorialD from a local file or a HTTP/HTTPS URI
+
 # 2020-12-27 (v0.9.0)
 
 * replace unmaintained distributed-process-client-server RPC package with new curryer RPC package
@@ -97,7 +102,7 @@
 
 * fix atom function type validation
 * add support for GHC 8.4 (now we support GHC 8.0, 8.2, and 8.4)
-	
+
 # 2018-08-10 (v0.5)
 
 * fix critical type bug which allowed unresolved types to be used
@@ -124,8 +129,8 @@
 
 * alter websocket server API to allow for multiple representations (JSON, text, or HTML) to be selected and returned simultaneously
 * add jupyter kernel for TutorialD interpreter
-* fix warnings suggested by new hlint 2.0.10	
-	
+* fix warnings suggested by new hlint 2.0.10
+
 # 2017-10-08 (v0.3)
 
 * replaced overuse of `undefined` with `Proxy` in `Tupleable` and `Atomable` typeclasses

--- a/cabal.project
+++ b/cabal.project
@@ -4,5 +4,42 @@ packages:
 package *
   split-sections: True
 
--- allow fast-builder to build with GHC 9.2.2 (currently pegged at 9.0.1)
-allow-newer: fast-builder:base
+-- Required patch from head.hackage to fix:
+--   * `winery` compilation with GHC-9.6
+--   * `barbies-th` compilation with GHC-9.8
+if impl(ghc >= 9.6)
+  repository head.hackage.ghc.haskell.org
+   url: https://ghc.gitlab.haskell.org/head.hackage/
+   secure: True
+   key-threshold: 3
+   root-keys:
+       26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+       7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+       f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+
+-- Loosened dependency bounds for compatibility with various versions of GHC.
+-- Remove these upper bound relaxations once the dependency has a new version
+-- released with higher upper bounds.
+--
+-- Note: The 'allow-newer' fields are /concatenative/, meaning that each
+-- conditional statement which is satisfied will have thier listed packages
+-- unioned together into an aggregated set of 'allow-newer' packages constraints.
+-- Hence the 'allow-newer' constraints /accumulate/ as GHC versions increase.  
+if impl(ghc >= 9.6)
+  allow-newer:
+    barbies-th:base,
+    barbies-th:template-haskell,
+    fast-builder:base,
+
+if impl(ghc >= 9.8)
+  allow-newer:
+    curryer-rpc:base,
+    streamly-bytestring:bytestring,
+
+if impl(ghc >= 9.10)
+  allow-newer:
+    streamly:base,
+    streamly:template-haskell,
+    streamly-core:base,
+    streamly-core:template-haskell,
+    websockets:containers,

--- a/examples/SimpleClient.hs
+++ b/examples/SimpleClient.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+-- This suppresses the incomplete pattern match on @(Right tupSet)@
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 import ProjectM36.Client
 import ProjectM36.TupleSet
 import ProjectM36.Relation.Show.Term
@@ -7,7 +10,7 @@ main :: IO ()
 main = do
   -- 1. create a ConnectionInfo
   let connInfo = RemoteConnectionInfo "mytestdb" "127.0.0.1" (show defaultServerPort) emptyNotificationCallback
-  -- 2. conncted to the remote database
+  -- 2. connected to the remote database
   eConn <- connectProjectM36 connInfo
   case eConn of
     Left err -> print err

--- a/examples/blog.hs
+++ b/examples/blog.hs
@@ -27,7 +27,7 @@ import Web.Scotty as S
 import Text.Blaze.Html5 (h1, h2, h3, p, form, input, (!), toHtml, Html, a, toValue, hr, textarea)
 import Text.Blaze.Html5.Attributes (name, href, type_, method, action, value)
 import Text.Blaze.Html.Renderer.Text
-import Control.Monad.IO.Class (liftIO)
+--import Control.Monad.IO.Class (liftIO)
 import Network.HTTP.Types.Status
 import Data.Time.Format.ISO8601
 

--- a/project-m36.cabal
+++ b/project-m36.cabal
@@ -1,6 +1,6 @@
 Cabal-Version: 2.2
 Name: project-m36
-Version: 1.0.2
+Version: 1.1.0
 License: MIT
 --note that this license specification is erroneous and only labeled MIT to appease hackage which does not recognize public domain packages in cabal >2.2- Project:M36 is dedicated to the public domain
 Build-Type: Simple
@@ -13,7 +13,7 @@ Maintainer: agentm@themactionfaction.com
 Synopsis: Relational Algebra Engine
 Description: A relational algebra engine which can be used to persist and query Haskell data types.
 Extra-Source-Files: Changelog.markdown README.markdown scripts/DateExamples.tutd scripts/multiline.tutd
-tested-with: GHC ==9.2.8 || ==9.4.8
+tested-with: GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.2 || ==9.10.1
 
 Source-Repository head
     Type: git
@@ -37,7 +37,7 @@ Flag haskell-scripting
 
 Library
     Build-Depends:
-                  base>=4.16 && < 4.19,
+                  base >=4.14 && < 5,
                   ghc-paths,
                   mtl,
                   containers,
@@ -98,7 +98,7 @@ Library
                   fast-builder,
                   scientific
     if flag(haskell-scripting)
-        Build-Depends: ghc >= 9.0 && < 9.5
+        Build-Depends: ghc >= 9.0
         CPP-Options: -DPM36_HASKELL_SCRIPTING
     if impl(ghc>= 8) && flag(haskell-scripting)
       build-depends:
@@ -213,7 +213,9 @@ Library
       Other-Modules: ProjectM36.Win32Handle
     else
       --219-  too many exported symbols under Windows and GHC 8.4
-      GHC-Options: -rdynamic -fexternal-interpreter -eventlog
+      GHC-Options: -rdynamic -fexternal-interpreter
+      if impl(ghc <9.4)
+        GHC-Options: -eventlog
       C-sources: cbits/DirectoryFsync.c, cbits/darwin_statfs.c
       Build-Depends: unix
     CC-Options: -fPIC
@@ -225,7 +227,7 @@ Library
 
 Executable tutd
     if flag(haskell-scripting)
-        Build-Depends: ghc >= 9.0 && < 9.5
+        Build-Depends: ghc >= 9.0
     Build-Depends: base >=4.8,
                    ghc-paths,
                    project-m36,
@@ -291,10 +293,11 @@ Executable tutd
                    ProjectM36.Interpreter
     main-is: TutorialD/tutd.hs
     CC-Options: -fPIC
-    if os(windows)
-      GHC-Options: -Wall -threaded -eventlog -rtsopts
-    else
-      GHC-Options: -Wall -threaded -rdynamic -eventlog -rtsopts
+    GHC-Options: -Wall -threaded -rtsopts
+    if !os(windows)
+      GHC-Options: -rdynamic
+    if impl(ghc <9.4)
+      GHC-Options: -eventlog
     if flag(profiler)
       GHC-Prof-Options: -fprof-auto -rtsopts -threaded
     Hs-Source-Dirs: ./src/bin
@@ -303,7 +306,7 @@ Executable tutd
 
 Executable sqlegacy
     if flag(haskell-scripting)
-        Build-Depends: ghc >= 9.0 && < 9.5
+        Build-Depends: ghc >= 9.0
     Build-Depends: base,
                    ghc-paths,
                    project-m36,
@@ -377,7 +380,7 @@ Executable sqlegacy
 
 Executable project-m36-server
     if flag(haskell-scripting)
-        Build-Depends: ghc >= 9.0 && < 9.5
+        Build-Depends: ghc >= 9.0
     Build-Depends: base,
                    ghc-paths,
                    transformers,
@@ -428,7 +431,9 @@ Executable bigrel
     GHC-Options: -Wall -threaded -rtsopts
     HS-Source-Dirs: ./src/bin
     if flag(profiler)
-      GHC-Prof-Options: -fprof-auto -rtsopts -threaded -Wall -eventlog
+      GHC-Prof-Options: -fprof-auto -rtsopts -threaded -Wall
+      if impl(ghc <9.4)
+        GHC-Prof-Options: -eventlog
 
 Common commontest
     Default-Language: Haskell2010
@@ -548,7 +553,10 @@ benchmark ondiskclient
     import: commontest
     type: exitcode-stdio-1.0
     main-is: benchmark/OnDiskClient.hs
-    GHC-Options: -rtsopts -Wall -threaded -eventlog -finfo-table-map -fdistinct-constructor-tables
+    GHC-Prof-Options: -fprof-auto -rtsopts -threaded -Wall
+    GHC-Options: -rtsopts -Wall -threaded -finfo-table-map -fdistinct-constructor-tables
+    if impl(ghc <9.4)
+      GHC-Options: -eventlog
 
 Test-Suite test-server
     import: commontest

--- a/src/bin/TutorialD/Interpreter/RODatabaseContextOperator.hs
+++ b/src/bin/TutorialD/Interpreter/RODatabaseContextOperator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 module TutorialD.Interpreter.RODatabaseContextOperator where
 import ProjectM36.Base
@@ -12,7 +13,11 @@ import TutorialD.Interpreter.Base
 import TutorialD.Interpreter.RelationalExpr
 import TutorialD.Interpreter.DatabaseContextExpr
 import TutorialD.Printer
+#if MIN_VERSION_base(4,18,0)
+import Control.Monad (when)
+#else
 import Control.Monad.State
+#endif
 import qualified Data.Text as T
 import ProjectM36.Relation.Show.Gnuplot
 import ProjectM36.HashSecurely

--- a/src/bin/benchmark/bigrel.hs
+++ b/src/bin/benchmark/bigrel.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleInstances, CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+-- This suppresses the incomplete pattern match on @Right x@ in 'matrixRun'
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 import ProjectM36.Base
 import ProjectM36.Relation
 import ProjectM36.DateExamples
@@ -111,7 +113,7 @@ vectorMatrixRun = do
 
 -- 20 s 90 MBs- a clear win- ideal size is 10 * 100000 * 8 bytes = 80 MB! without IntAtom wrapper
 --with IntAtom wrapper: 1m12s 90 MB
-{-                    
+{-
 
 vectorMatrixRelation :: Int -> Int -> HS.HashSet (V.Vector Atom)
 vectorMatrixRelation attributeCount tupleCount = HS.fromList $ map mapper [0..tupleCount]
@@ -129,4 +131,3 @@ matrixRelation attributeCount tupleCount = do
       tuple tupleX = RelationTuple attrs (V.generate attributeCount (\_ -> IntAtom (fromIntegral tupleX)))
       tuples = map tuple [0 .. tupleCount]
   mkRelationDeferVerify attrs (RelationTupleSet tuples)
-

--- a/src/lib/ProjectM36/AtomFunction.hs
+++ b/src/lib/ProjectM36/AtomFunction.hs
@@ -18,12 +18,10 @@ foldAtomFuncType foldType returnType =
    returnType]
 
 atomFunctionForName :: FunctionName -> AtomFunctions -> Either RelationalError AtomFunction
-atomFunctionForName funcName' funcSet = if HS.null foundFunc then
-                                         Left $ NoSuchFunctionError funcName'
-                                        else
-                                         Right $ head $ HS.toList foundFunc
-  where
-    foundFunc = HS.filter (\f -> funcName f == funcName') funcSet
+atomFunctionForName funcName' funcSet =
+  case HS.toList  $ HS.filter (\f -> funcName f == funcName') funcSet of
+    [] -> Left $ NoSuchFunctionError funcName'
+    x : _ -> Right x
 
 -- | Create a junk named atom function for use with searching for an already existing function in the AtomFunctions HashSet.
 emptyAtomFunction :: FunctionName -> AtomFunction

--- a/src/lib/ProjectM36/AttributeNames.hs
+++ b/src/lib/ProjectM36/AttributeNames.hs
@@ -1,7 +1,10 @@
 module ProjectM36.AttributeNames where
 import ProjectM36.Base
 import qualified Data.Set as S
-import Data.List (foldl')
+#if MIN_VERSION_base(4,20,0)
+#else
+import Data.Foldable (foldl')
+#endif
 --AttributeNames is a data structure which can represent inverted projection attributes and attribute names derived from relational expressions
 
 empty :: AttributeNamesBase a

--- a/src/lib/ProjectM36/Client.hs
+++ b/src/lib/ProjectM36/Client.hs
@@ -122,7 +122,10 @@ import ProjectM36.Key
 import qualified ProjectM36.DataFrame as DF
 import ProjectM36.DatabaseContextFunction as DCF
 import qualified ProjectM36.IsomorphicSchema as Schema
-import Control.Monad.State
+#if MIN_VERSION_base(4,16,0)
+import Control.Monad (forever, forM, forM_, unless, void)
+#endif
+--import Control.Monad.State
 import qualified ProjectM36.RelationalExpression as RE
 import qualified ProjectM36.TransactionGraph as Graph
 import ProjectM36.TransactionGraph as TG

--- a/src/lib/ProjectM36/Client/Simple.hs
+++ b/src/lib/ProjectM36/Client/Simple.hs
@@ -31,6 +31,9 @@ module ProjectM36.Client.Simple (
   ) where
 
 import Control.Exception.Base
+#if MIN_VERSION_ghc(9,6,0)
+import Control.Monad ((<=<))
+#endif
 import Control.Monad.Reader
 import ProjectM36.Base
 import qualified ProjectM36.Client as C

--- a/src/lib/ProjectM36/DatabaseContextFunction.hs
+++ b/src/lib/ProjectM36/DatabaseContextFunction.hs
@@ -24,12 +24,10 @@ emptyDatabaseContextFunction name = Function {
   }
 
 databaseContextFunctionForName :: FunctionName -> DatabaseContextFunctions -> Either RelationalError DatabaseContextFunction
-databaseContextFunctionForName funcName' funcs = if HS.null foundFunc then
-                                                   Left $ NoSuchFunctionError funcName'
-                                                else
-                                                  Right (head (HS.toList foundFunc))
-  where
-    foundFunc = HS.filter (\f -> funcName f == funcName') funcs
+databaseContextFunctionForName funcName' funcs =
+  case HS.toList $ HS.filter (\f -> funcName f == funcName') funcs of
+    [] -> Left $ NoSuchFunctionError funcName'
+    x : _ -> Right x
 
 evalDatabaseContextFunction :: DatabaseContextFunction -> [Atom] -> DatabaseContext -> Either RelationalError DatabaseContext
 evalDatabaseContextFunction func args ctx =

--- a/src/lib/ProjectM36/Error.hs
+++ b/src/lib/ProjectM36/Error.hs
@@ -125,10 +125,8 @@ data PersistenceError = InvalidDirectoryError FilePath |
 --collapse list of errors into normal error- if there is just one, just return one
 someErrors :: [RelationalError] -> RelationalError                                      
 someErrors [] = error "no errors in error list: function misuse" 
-someErrors errList  = if length errList == 1 then
-                        head errList
-                      else
-                        MultipleErrors errList
+someErrors [err] = err
+someErrors errList = MultipleErrors errList
                         
 data MergeError = SelectedHeadMismatchMergeError |
                   PreferredHeadMissingMergeError HeadName |

--- a/src/lib/ProjectM36/Function.hs
+++ b/src/lib/ProjectM36/Function.hs
@@ -52,9 +52,7 @@ loadFunctions _ _ _ _ = pure (Left LoadSymbolError)
 #endif
 
 functionForName :: FunctionName -> HS.HashSet (Function a) -> Either RelationalError (Function a)
-functionForName funcName' funcSet = if HS.null foundFunc then
-                                         Left $ NoSuchFunctionError funcName'
-                                        else
-                                         Right $ head $ HS.toList foundFunc
-  where
-    foundFunc = HS.filter (\f -> funcName f == funcName') funcSet
+functionForName funcName' funcSet =
+  case HS.toList $ HS.filter (\f -> funcName f == funcName') funcSet of
+    [] -> Left $ NoSuchFunctionError funcName'
+    x : _ -> Right x

--- a/src/lib/ProjectM36/GraphRefRelationalExpr.hs
+++ b/src/lib/ProjectM36/GraphRefRelationalExpr.hs
@@ -24,12 +24,11 @@ instance Monoid SingularTransactionRef where
   
 -- | return `Just transid` if this GraphRefRelationalExpr refers to just one transaction in the graph. This is useful for determining if certain optimizations can apply.
 singularTransaction :: Foldable t => t GraphRefTransactionMarker -> SingularTransactionRef
-singularTransaction expr
-  | S.null transSet = NoTransactionsRef
-  | S.size transSet == 1 = SingularTransactionRef (head (S.toList transSet))
-  | otherwise = MultipleTransactionsRef
-  where
-    transSet = foldr S.insert S.empty expr
+singularTransaction expr = case S.toList $ foldr S.insert S.empty expr of
+  [] -> NoTransactionsRef
+  x : xs -> case xs of
+    [] -> SingularTransactionRef x
+    _ -> MultipleTransactionsRef
 
 -- | Return True if two 'GraphRefRelationalExpr's both refer exclusively to the same transaction (or none at all).
 inSameTransaction :: GraphRefRelationalExpr -> GraphRefRelationalExpr -> Maybe GraphRefTransactionMarker

--- a/src/lib/ProjectM36/Relation.hs
+++ b/src/lib/ProjectM36/Relation.hs
@@ -73,10 +73,12 @@ relationFalse = Relation A.emptyAttributes emptyTupleSet
 
 --if the relation contains one tuple, return it, otherwise Nothing
 singletonTuple :: Relation -> Maybe RelationTuple
-singletonTuple rel@(Relation _ tupleSet) = if cardinality rel == Finite 1 then
-                                         Just $ head $ asList tupleSet
-                                       else
-                                         Nothing
+singletonTuple rel@(Relation _ tupleSet) =
+  case cardinality rel of
+    Countable -> Nothing
+    _ -> case asList tupleSet of
+      [] -> Nothing
+      x : _ -> Just x
 
 -- this is still unncessarily expensive for (bigx union bigx) because each tuple is hashed and compared for equality (when the hashes match), but the major expense is attributesEqual, but we already know that all tuple attributes are equal (it's a precondition)
 union :: Relation -> Relation -> Either RelationalError Relation

--- a/src/lib/ProjectM36/Relation/Show/Term.hs
+++ b/src/lib/ProjectM36/Relation/Show/Term.hs
@@ -136,9 +136,11 @@ renderBody :: [[Cell]] -> ([Int],[Int]) -> StringType
 renderBody cellMatrix cellLocs = renderRows `T.append` renderBottomBar
   where
     columnLocations = fst cellLocs
-    rowLocations = snd cellLocs
-    renderRows = T.concat (map (\(row, rowHeight)-> renderRow row columnLocations rowHeight boxV) rowHeightMatrix)
-    rowHeightMatrix = zip cellMatrix (tail rowLocations)
+    rowLocations = case snd cellLocs of
+      [] -> []
+      _ : xs -> xs
+    renderRows = T.concat (map (\(row, rowHeight) -> renderRow row columnLocations rowHeight boxV) rowHeightMatrix)
+    rowHeightMatrix = zip cellMatrix rowLocations
     renderBottomBar = renderHBar boxBL boxBB boxBR columnLocations
 
 repeatString :: Int -> StringType -> StringType

--- a/src/lib/ProjectM36/SQL/Convert.hs
+++ b/src/lib/ProjectM36/SQL/Convert.hs
@@ -32,7 +32,10 @@ import Control.Monad.Trans.State (StateT, get, put, runStateT, evalStateT)
 import Control.Monad.Trans.Except (ExceptT, throwE, runExceptT)
 import Control.Monad.Identity (Identity, runIdentity)
 import Control.Monad.Trans.Class (lift)
+#if MIN_VERSION_base(4,20,0)
+#else
 import Data.Foldable (foldl')
+#endif
 import Data.Bifunctor (bimap)
 --import qualified Data.HashSet as HS
 

--- a/src/lib/ProjectM36/ScriptSession.hs
+++ b/src/lib/ProjectM36/ScriptSession.hs
@@ -22,14 +22,30 @@ import System.Environment
 
 import Unsafe.Coerce
 import GHC.LanguageExtensions (Extension(OverloadedStrings,ExtendedDefaultRules,ImplicitPrelude,ScopedTypeVariables))
-
+#if MIN_VERSION_ghc(9,6,0)
+import Data.List.NonEmpty(NonEmpty(..))
+#else
+#endif
+#if MIN_VERSION_ghc(9,6,0)
+#else
+#endif
+#if MIN_VERSION_ghc(9,6,0)
+import GHC.Core.TyCo.Compare (eqType)
+#elif MIN_VERSION_ghc(9,0,0)
+import GHC.Core.Type (eqType)
+#else
+import Type (eqType)
+#endif
+#if MIN_VERSION_ghc(9,6,0)
+#elif MIN_VERSION_ghc(9,0,0)
+import GHC.Unit.Types (IsBootInterface(NotBoot))
+#else
+#endif
 #if MIN_VERSION_ghc(9,4,0)
 import GHC.Utils.Panic (handleGhcException)
 import GHC.Driver.Session (projectVersion, PackageDBFlag(PackageDB), PkgDbRef(PkgDbPath), TrustFlag(TrustPackage), gopt_set, xopt_set, PackageFlag(ExposePackage), PackageArg(PackageArg), ModRenaming(ModRenaming))
 import GHC.Types.SourceText (SourceText(NoSourceText))
-import GHC.Unit.Types (IsBootInterface(NotBoot))
 import GHC.Driver.Ppr (showSDocForUser)
-import GHC.Core.Type (eqType)
 import GHC.Core.TyCo.Ppr (pprType)
 import GHC.Utils.Encoding (zEncodeString)
 import GHC.Unit.State (emptyUnitState)
@@ -39,9 +55,7 @@ import GHC.Types.PkgQual (RawPkgQual(NoRawPkgQual))
 import GHC.Utils.Panic (handleGhcException)
 import GHC.Driver.Session (projectVersion, PackageDBFlag(PackageDB), PkgDbRef(PkgDbPath), TrustFlag(TrustPackage), gopt_set, xopt_set, PackageFlag(ExposePackage), PackageArg(PackageArg), ModRenaming(ModRenaming))
 import GHC.Types.SourceText (SourceText(NoSourceText))
-import GHC.Unit.Types (IsBootInterface(NotBoot))
 import GHC.Driver.Ppr (showSDocForUser)
-import GHC.Core.Type (eqType)
 import GHC.Types.TyThing.Ppr (pprTypeForUser)
 import GHC.Utils.Encoding (zEncodeString)
 import GHC.Unit.State (emptyUnitState)
@@ -50,8 +64,6 @@ import GHC.Unit.State (emptyUnitState)
 import GHC.Utils.Panic (handleGhcException)
 import GHC.Driver.Session (projectVersion, PackageDBFlag(PackageDB), PkgDbRef(PkgDbPath), TrustFlag(TrustPackage), gopt_set, xopt_set, PackageFlag(ExposePackage), PackageArg(PackageArg), ModRenaming(ModRenaming))
 import GHC.Types.Basic (SourceText(NoSourceText))
-import GHC.Unit.Types (IsBootInterface(NotBoot))
-import GHC.Core.Type (eqType)
 import GHC.Utils.Outputable (showSDocForUser)
 import GHC.Utils.Encoding (zEncodeString)
 import GHC.Core.Ppr.TyThing (pprTypeForUser)
@@ -60,7 +72,6 @@ import GHC.Core.Ppr.TyThing (pprTypeForUser)
 import BasicTypes (SourceText(NoSourceText))
 import Outputable (showSDocForUser)
 import PprTyThing (pprTypeForUser)
-import Type (eqType)
 import Encoding (zEncodeString)
 import Panic (handleGhcException)
 import DynFlags (projectVersion, PkgConfRef(PkgConfFile), TrustFlag(TrustPackage), gopt_set, xopt_set, PackageFlag(ExposePackage), PackageArg(PackageArg), ModRenaming(ModRenaming), PackageDBFlag(PackageDB))
@@ -126,7 +137,9 @@ initScriptSession ghcPkgPaths = do
     let localPkgPaths = map pkgConf (ghcPkgPaths ++ sandboxPkgPaths ++ maybeToList mNixLibDir)
 
     let dflags' = applyGopts . applyXopts $ dflags {
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,6,0)
+                           backend = interpreterBackend,
+#elif MIN_VERSION_ghc(9,2,0)
                            backend = Interpreter,
 #else  
                            hscTarget = HscInterpreted ,
@@ -165,13 +178,32 @@ initScriptSession ghcPkgPaths = do
   --liftIO $ traceShowM (showSDoc dflags' (ppr packages))
     _ <- setSessionDynFlags dflags'
     let safeImportDecl :: String -> Maybe String -> ImportDecl (GhcPass 'Parsed)
-        safeImportDecl fullModuleName mQualifiedName = ImportDecl {
+        safeImportDecl fullModuleName _mQualifiedName = ImportDecl {
+#if MIN_VERSION_ghc(9,6,0)
+#else
           ideclSourceSrc = NoSourceText,
-
-#if MIN_VERSION_ghc(9,2,0)
+#endif
+#if MIN_VERSION_ghc(9,6,0)
+          ideclImportList = Nothing,
+#endif
+#if MIN_VERSION_ghc(9,10,0)
+          ideclExt = XImportDeclPass
+            { ideclAnn = noAnn
+            , ideclSourceText = NoSourceText
+            , ideclImplicit = False
+            },
+#elif MIN_VERSION_ghc(9,6,0)
+          ideclExt = XImportDeclPass
+            { ideclAnn = EpAnnNotUsed
+            , ideclSourceText = NoSourceText
+            , ideclImplicit = False
+            },
+#elif MIN_VERSION_ghc(9,2,0)
           ideclExt = noAnn,
+          ideclImplicit  = False,
 #else
           ideclExt = noExtField,
+          ideclImplicit  = False,
 #endif
 #if MIN_VERSION_ghc(9,2,0)
           --GenLocated SrcSpanAnnA ModuleName
@@ -189,16 +221,21 @@ initScriptSession ghcPkgPaths = do
 #else
           ideclSource    = False,
 #endif
-
-          ideclSafe      = True,
-          ideclImplicit  = False,
-          ideclQualified = if isJust mQualifiedName then QualifiedPre else NotQualified,
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,4,0)
+          ideclQualified = if isJust _mQualifiedName then QualifiedPre else NotQualified,
+#endif
+#if MIN_VERSION_ghc(9,6,0)
+          ideclAs        = Nothing,
+#elif MIN_VERSION_ghc(9,2,0)
           ideclAs        = Just (noLocA (mkModuleName fullModuleName)),
 #else
-          ideclAs        = noLoc . mkModuleName <$> mQualifiedName,
+          ideclAs        = noLoc . mkModuleName <$> _mQualifiedName,
 #endif
-          ideclHiding    = Nothing
+#if MIN_VERSION_ghc(9,6,0)
+#else
+          ideclHiding    = Nothing,
+#endif
+          ideclSafe      = True
           }
         unqualifiedModules = map (\modn -> IIDecl $ safeImportDecl modn Nothing) [
           "Prelude",
@@ -239,9 +276,14 @@ mkTypeForName :: String -> Ghc Type
 mkTypeForName name = do
   lBodyName <- parseName name
   case lBodyName of
+#if MIN_VERSION_ghc(9,6,0)
+    _ :| (_:_) -> error "too many name matches"
+    bodyName :| _ -> do
+#else
     [] -> error ("failed to parse " ++ name)
     _:_:_ -> error "too many name matches"
     [bodyName] -> do
+#endif
       mThing <- lookupName bodyName
       case mThing of
         Nothing -> error ("failed to find " ++ name)

--- a/src/lib/ProjectM36/TransactionGraph.hs
+++ b/src/lib/ProjectM36/TransactionGraph.hs
@@ -16,8 +16,14 @@ import ProjectM36.HashSecurely
 import ProjectM36.ReferencedTransactionIds
 
 import Codec.Winery
+#if MIN_VERSION_ghc(9,6,0)
+import Control.Monad (foldM, forM, unless, when)
+import Control.Monad.Except
+import Control.Monad.Reader
+#else
 import Control.Monad.Except hiding (join)
 import Control.Monad.Reader hiding (join)
+#endif
 import qualified Data.Vector as V
 import qualified Data.UUID as U
 import qualified Data.Set as S
@@ -39,15 +45,15 @@ data TransactionIdLookup = TransactionIdLookup TransactionId |
                            TransactionIdHeadNameLookup HeadName [TransactionIdHeadBacktrack]
                            deriving (Show, Eq, Generic)
                            deriving Serialise via WineryVariant TransactionIdLookup
-                           
+
 -- | Used for git-style head backtracking such as topic~3^2.
 data TransactionIdHeadBacktrack = TransactionIdHeadParentBacktrack Int | -- ^ git equivalent of ~v: walk back n parents, arbitrarily choosing a parent when a choice must be made
-                                  TransactionIdHeadBranchBacktrack Int | -- ^ git equivalent of ^: walk back one parent level to the nth arbitrarily-chosen parent 
+                                  TransactionIdHeadBranchBacktrack Int | -- ^ git equivalent of ^: walk back one parent level to the nth arbitrarily-chosen parent
                                   TransactionStampHeadBacktrack UTCTime -- ^ git equivalent of 'git-rev-list -n 1 --before X' find the first transaction which was created before the timestamp
                                   deriving (Show, Eq, Generic)
                                   deriving Serialise via WineryVariant TransactionIdHeadBacktrack
 
-  
+
 -- | Operators which manipulate a transaction graph and which transaction the current 'Session' is based upon.
 data TransactionGraphOperator = JumpToHead HeadName  |
                                 JumpToTransaction TransactionId |
@@ -59,11 +65,11 @@ data TransactionGraphOperator = JumpToHead HeadName  |
                                 Rollback
                               deriving (Eq, Show, Generic)
                               deriving Serialise via WineryVariant TransactionGraphOperator
-                                       
-isCommit :: TransactionGraphOperator -> Bool                                       
+
+isCommit :: TransactionGraphOperator -> Bool
 isCommit Commit = True
 isCommit _ = False
-                                       
+
 data ROTransactionGraphOperator = ShowGraph | ValidateMerkleHashes
                                   deriving Show
 
@@ -94,12 +100,10 @@ headList :: TransactionGraph -> [(HeadName, TransactionId)]
 headList graph = map (second transactionId) (M.assocs (transactionHeadsForGraph graph))
 
 headNameForTransaction :: Transaction -> TransactionGraph -> Maybe HeadName
-headNameForTransaction transaction (TransactionGraph heads _) = if M.null matchingTrans then
-                                                                  Nothing
-                                                                else
-                                                                  Just $ (head . M.keys) matchingTrans
-  where
-    matchingTrans = M.filter (transaction ==) heads
+headNameForTransaction transaction (TransactionGraph heads _) =
+  case M.keys $ M.filter (transaction ==) heads of
+    [] -> Nothing
+    name : _ -> Just name
 
 transactionsForIds :: S.Set TransactionId -> TransactionGraph -> Either RelationalError (S.Set Transaction)
 transactionsForIds idSet graph =
@@ -148,7 +152,7 @@ addTransactionToGraph headName newTrans graph = do
   when (S.size parentIds' < 1) (Left $ NewTransactionMissingParentError newId)
   --if the headName already exists, ensure that it refers to a parent
   case transactionForHead headName graph of
-    Nothing -> pure () -- any headName is OK 
+    Nothing -> pure () -- any headName is OK
     Just trans -> when (S.notMember (transactionId trans) parentIds') (Left (HeadNameSwitchingHeadProhibitedError headName))
   --validate that the transaction has no children
   unless (S.null childTs) (Left $ NewTransactionMayNotHaveChildrenError newId)
@@ -171,10 +175,10 @@ newTransUncommittedReplace trans@(Transaction tid tinfo (Schemas ctx sschemas)) 
   where
   uncommittedReplace UncommittedContextMarker = TransactionMarker tid
   uncommittedReplace marker = marker
-  relvars = relationVariables (concreteDatabaseContext trans)  
+  relvars = relationVariables (concreteDatabaseContext trans)
   fixedRelvars = M.map (fmap uncommittedReplace) relvars
   fixedContext = ctx { relationVariables = fixedRelvars }
-  
+
 
 
 validateGraph :: TransactionGraph -> Maybe [RelationalError]
@@ -240,16 +244,16 @@ evalGraphOp _ _ _ graph (JumpToHead headName) =
     Just newHeadTransaction -> let disconnectedTrans = DisconnectedTransaction (transactionId newHeadTransaction) (schemas newHeadTransaction) False in
       Right (disconnectedTrans, graph)
     Nothing -> Left $ NoSuchHeadNameError headName
-    
+
 evalGraphOp _ _ discon graph (WalkBackToTime backTime) = do
   let startTransId = Discon.parentId discon
-  jumpDest <- backtrackGraph graph startTransId (TransactionStampHeadBacktrack backTime) 
+  jumpDest <- backtrackGraph graph startTransId (TransactionStampHeadBacktrack backTime)
   case transactionForId jumpDest graph of
     Left err -> Left err
     Right trans -> do
       let disconnectedTrans = Discon.freshTransaction (transactionId trans) (schemas trans)
       Right (disconnectedTrans, graph)
-              
+
 -- add new head pointing to branchPoint
 -- repoint the disconnected transaction to the new branch commit (with a potentially different disconnected context)
 -- affects transactiongraph and the disconnectedtransaction is recreated based off the branch
@@ -270,7 +274,7 @@ evalGraphOp stamp' newId (DisconnectedTransaction parentId schemas' _) graph (Br
   case addBranch stamp' newId newBranchName parentId graph of
     Left err -> Left err
     Right (_, newGraph) -> Right (newDiscon, newGraph)
-  
+
 -- add the disconnected transaction to the graph
 -- affects graph and disconnectedtransaction- the new disconnectedtransaction's parent is the freshly committed transaction
 evalGraphOp stamp' newTransId discon@(DisconnectedTransaction parentId schemas' _) graph Commit = case transactionForId parentId graph of
@@ -290,8 +294,8 @@ evalGraphOp _ _ (DisconnectedTransaction parentId _ _) graph Rollback = case tra
   Right parentTransaction -> Right (newDiscon, graph)
     where
       newDiscon = Discon.freshTransaction parentId (schemas parentTransaction)
-      
-evalGraphOp stamp' newId (DisconnectedTransaction parentId _ _) graph (MergeTransactions mergeStrategy headNameA headNameB) = 
+
+evalGraphOp stamp' newId (DisconnectedTransaction parentId _ _) graph (MergeTransactions mergeStrategy headNameA headNameB) =
   runGraphRefRelationalExprM env $ mergeTransactions stamp' newId parentId mergeStrategy (headNameA, headNameB)
   where
     env = freshGraphRefRelationalExprEnv Nothing graph
@@ -325,8 +329,8 @@ graphAsRelation (DisconnectedTransaction parentId _ _) graph@(TransactionGraph _
                                       ]
 
 transactionParentsRelation :: Transaction -> TransactionGraph -> Either RelationalError Relation
-transactionParentsRelation trans graph = 
-  if isRootTransaction trans then    
+transactionParentsRelation trans graph =
+  if isRootTransaction trans then
     mkRelation attrs emptyTupleSet
     else do
       parentTransSet <- parentTransactions trans graph
@@ -355,7 +359,7 @@ createMergeTransaction stamp' newId (SelectedBranchMergeStrategy selectedBranch)
                                                  transactionId trans2],
                           stamp = stamp',
                           merkleHash = mempty }) (schemas selectedTrans)
-                       
+
 -- merge functions, relvars, individually
 createMergeTransaction stamp' newId strat@UnionMergeStrategy t2 =
   createUnionMergeTransaction stamp' newId strat t2
@@ -369,11 +373,11 @@ validateHeadName :: HeadName -> TransactionGraph -> (Transaction, Transaction) -
 validateHeadName headName graph (t1, t2) =
   case transactionForHead headName graph of
     Nothing -> throwError (MergeTransactionError SelectedHeadMismatchMergeError)
-    Just trans -> if trans /= t1 && trans /= t2 then 
+    Just trans -> if trans /= t1 && trans /= t2 then
                     throwError (MergeTransactionError SelectedHeadMismatchMergeError)
                   else
                     pure trans
-  
+
 -- Algorithm: start at one transaction and work backwards up the parents. If there is a node we have not yet visited as a child, then walk that up to its head. If that branch contains the goal transaction, then we have completed a valid subgraph traversal. The subgraph must also include any transactions which are referenced by other transactions.
 subGraphOfFirstCommonAncestor :: TransactionGraph -> TransactionHeads -> Transaction -> Transaction -> S.Set Transaction -> Either RelationalError TransactionGraph
 subGraphOfFirstCommonAncestor origGraph resultHeads currentTrans' goalTrans traverseSet = do
@@ -390,8 +394,10 @@ subGraphOfFirstCommonAncestor origGraph resultHeads currentTrans' goalTrans trav
         errors = lefts childSearches
         pathsFound = rights childSearches
         realErrors = filter (/= FailedToFindTransactionError goalid) errors
-    -- report any non-search-related errors        
-    unless (null realErrors) (Left (head realErrors))
+    -- report any non-search-related errors
+    case realErrors of
+      [] -> pure ()
+      err : _ -> Left err
     -- if no paths found, search the parent
     if null pathsFound then
       case oneParent currentTrans' of
@@ -409,7 +415,7 @@ subGraphOfFirstCommonAncestor origGraph resultHeads currentTrans' goalTrans trav
         Right (TransactionGraph resultHeads closedTransactionSet)
   where
     oneParent (Transaction _ tinfo _) = transactionForId (NE.head (parents tinfo)) origGraph
-    
+
 -- | Search from a past graph point to all following heads for a specific transaction. If found, return the transaction path, otherwise a RelationalError.
 pathToTransaction :: TransactionGraph -> Transaction -> Transaction -> S.Set Transaction -> Either RelationalError (S.Set Transaction)
 pathToTransaction graph currentTransaction targetTransaction accumTransSet = do
@@ -424,12 +430,14 @@ pathToTransaction graph currentTransaction targetTransaction accumTransSet = do
       let searches = map (\t -> pathToTransaction graph t targetTransaction (S.insert t accumTransSet)) (S.toList currentTransChildren)
       let realErrors = filter (/= FailedToFindTransactionError targetId) (lefts searches)
           paths = rights searches
-      if not (null realErrors) then -- found some real errors
-        Left (head realErrors)
-      else if null paths then -- failed to find transaction in all children
-             Left (FailedToFindTransactionError targetId)
-           else --we have some paths!
-             Right (S.unions paths)
+      case realErrors of
+        -- found some real errors
+        err : _ -> Left err
+        [] -> case paths of
+          -- failed to find transaction in all children
+          [] -> Left $ FailedToFindTransactionError targetId
+          -- we have some paths!
+          _ -> Right $ S.unions paths
 
 mergeTransactions :: UTCTime -> TransactionId -> TransactionId -> MergeStrategy -> (HeadName, HeadName) -> GraphRefRelationalExprM (DisconnectedTransaction, TransactionGraph)
 mergeTransactions stamp' newId parentId mergeStrategy (headNameA, headNameB) = do
@@ -462,8 +470,8 @@ mergeTransactions stamp' newId parentId mergeStrategy (headNameA, headNameB) = d
               let newGraph' = TransactionGraph (transactionHeadsForGraph newGraph) (transactionsForGraph newGraph)
                   newDiscon = Discon.freshTransaction newId (schemas newTrans)
               pure (newDiscon, newGraph')
-  
---TEMPORARY COPY/PASTE  
+
+--TEMPORARY COPY/PASTE
 showTransactionStructureX :: Bool -> Transaction -> TransactionGraph -> String
 showTransactionStructureX showRelVars trans graph = headInfo ++ " " ++ show (transactionId trans) ++ " " ++ parentTransactionsInfo ++ relVarsInfo
   where
@@ -473,13 +481,13 @@ showTransactionStructureX showRelVars trans graph = headInfo ++ " " ++ show (tra
     parentTransactionsInfo = if isRootTransaction trans then "root" else case parentTransactions trans graph of
       Left err -> show err
       Right parentTransSet -> concat $ S.toList $ S.map (show . transactionId) parentTransSet
-  
+
 showGraphStructureX :: Bool -> TransactionGraph -> String
 showGraphStructureX showRelVars graph@(TransactionGraph heads transSet) = headsInfo ++ S.foldr folder "" transSet
   where
     folder trans acc = acc ++ showTransactionStructureX showRelVars trans graph ++ "\n"
     headsInfo = show $ M.map transactionId heads
-    
+
 -- | After splicing out a subgraph, run it through this function to remove references to transactions which are not in the subgraph.
 filterSubGraph :: TransactionGraph -> TransactionHeads -> Either RelationalError TransactionGraph
 filterSubGraph graph heads = Right $ TransactionGraph newHeads newTransSet
@@ -487,7 +495,7 @@ filterSubGraph graph heads = Right $ TransactionGraph newHeads newTransSet
     validIds = S.map transactionId (transactionsForGraph graph)
     newTransSet = S.map (filterTransaction validIds) (transactionsForGraph graph)
     newHeads = M.map (filterTransaction validIds) heads
-    
+
 --helper function for commonalities in union merge
 createUnionMergeTransaction :: UTCTime -> TransactionId -> MergeStrategy -> (Transaction, Transaction) -> GraphRefRelationalExprM Transaction
 createUnionMergeTransaction stamp' newId strategy (t1,t2) = do
@@ -496,16 +504,16 @@ createUnionMergeTransaction stamp' newId strategy (t1,t2) = do
       liftMergeE x = case x of
         Left e -> throwError (MergeTransactionError e)
         Right t -> pure t
-        
+
   graph <- gfGraph
-  preference <- case strategy of 
+  preference <- case strategy of
     UnionMergeStrategy -> pure PreferNeither
     UnionPreferMergeStrategy preferBranch ->
       case transactionForHead preferBranch graph of
         Nothing -> throwError (MergeTransactionError (PreferredHeadMissingMergeError preferBranch))
         Just preferredTrans -> pure $ if t1 == preferredTrans then PreferFirst else PreferSecond
     badStrat -> throwError (MergeTransactionError (InvalidMergeStrategyError badStrat))
-          
+
   incDeps <- liftMergeE $ unionMergeMaps preference (inclusionDependencies contextA) (inclusionDependencies contextB)
   relVars <- unionMergeRelVars preference (relationVariables contextA) (relationVariables contextB)
   atomFuncs <- liftMergeE $ unionMergeAtomFunctions preference (atomFunctions contextA) (atomFunctions contextB)
@@ -515,8 +523,8 @@ createUnionMergeTransaction stamp' newId strategy (t1,t2) = do
   registeredQs <- liftMergeE $ unionMergeRegisteredQueries preference (registeredQueries contextA) (registeredQueries contextB)
   -- TODO: add merge of subschemas
   let newContext = DatabaseContext {
-        inclusionDependencies = incDeps, 
-        relationVariables = relVars, 
+        inclusionDependencies = incDeps,
+        relationVariables = relVars,
         atomFunctions = atomFuncs,
         dbcFunctions = dbcFuncs,
         notifications = notifs,
@@ -533,15 +541,15 @@ createUnionMergeTransaction stamp' newId strategy (t1,t2) = do
 
 lookupTransaction :: TransactionGraph -> TransactionIdLookup -> Either RelationalError Transaction
 lookupTransaction graph (TransactionIdLookup tid) = transactionForId tid graph
-lookupTransaction graph (TransactionIdHeadNameLookup headName backtracks) = case transactionForHead headName graph of 
+lookupTransaction graph (TransactionIdHeadNameLookup headName backtracks) = case transactionForHead headName graph of
   Nothing -> Left (NoSuchHeadNameError headName)
   Just headTrans -> do
     traversedId <- traverseGraph graph (transactionId headTrans) backtracks
     transactionForId traversedId graph
-    
+
 traverseGraph :: TransactionGraph -> TransactionId -> [TransactionIdHeadBacktrack] -> Either RelationalError TransactionId
 traverseGraph graph = foldM (backtrackGraph graph)
-             
+
 backtrackGraph :: TransactionGraph -> TransactionId -> TransactionIdHeadBacktrack -> Either RelationalError TransactionId
 -- tilde, step back one parent link- if a choice must be made, choose the "first" link arbitrarily
 backtrackGraph graph currentTid (TransactionIdHeadParentBacktrack steps) = do
@@ -556,28 +564,26 @@ backtrackGraph graph currentTid (TransactionIdHeadParentBacktrack steps) = do
         pure (transactionId parentTrans)
         else
         backtrackGraph graph (transactionId parentTrans) (TransactionIdHeadParentBacktrack (steps - 1))
-  
+
 backtrackGraph graph currentTid (TransactionIdHeadBranchBacktrack steps) = do
   trans <- transactionForId currentTid graph
   let parentIds' = parentIds trans
   if S.size parentIds' < 1 then
-    Left RootTransactionTraversalError    
+    Left RootTransactionTraversalError
     else if S.size parentIds' < steps then
            Left (ParentCountTraversalError (S.size parentIds') steps)
          else
            pure (S.elemAt (steps - 1) parentIds')
-           
-backtrackGraph graph currentTid btrack@(TransactionStampHeadBacktrack stamp') = do           
+
+backtrackGraph graph currentTid btrack@(TransactionStampHeadBacktrack stamp') = do
   trans <- transactionForId currentTid graph
-  let parentIds' = parentIds trans  
+  let parentIds' = parentIds trans
   if timestamp trans <= stamp' then
     pure currentTid
-    else if S.null parentIds' then
-           Left RootTransactionTraversalError
-         else
-           let arbitraryParent = head (S.toList parentIds') in
-           backtrackGraph graph arbitraryParent btrack
-    
+    else case S.toList parentIds' of
+      [] -> Left RootTransactionTraversalError
+      arbitraryParent : _ -> backtrackGraph graph arbitraryParent btrack
+
 -- | Create a temporary branch for commit, merge the result to head, delete the temporary branch. This is useful to atomically commit a transaction, avoiding a TransactionIsNotHeadError but trading it for a potential MergeError.
 --this is not a GraphOp because it combines multiple graph operations
 autoMergeToHead :: UTCTime -> (TransactionId, TransactionId, TransactionId) -> DisconnectedTransaction -> HeadName -> MergeStrategy -> TransactionGraph -> Either RelationalError (DisconnectedTransaction, TransactionGraph)
@@ -585,23 +591,23 @@ autoMergeToHead stamp' (tempBranchTransId, tempCommitTransId, mergeTransId) disc
   let tempBranchName = "mergebranch_" <> U.toText tempBranchTransId
   --create the temp branch
   (discon', graph') <- evalGraphOp stamp' tempBranchTransId discon graph (Branch tempBranchName)
-  
+
   --commit to the new branch- possible future optimization: don't require fsync for this- create a temp commit type
   (discon'', graph'') <- evalGraphOp stamp' tempCommitTransId discon' graph' Commit
- 
+
   --jump to merge head
   (discon''', graph''') <- evalGraphOp stamp' tempBranchTransId discon'' graph'' (JumpToHead mergeToHeadName)
-  
+
   --create the merge
   (discon'''', graph'''') <- evalGraphOp stamp' mergeTransId discon''' graph''' (MergeTransactions strat tempBranchName mergeToHeadName)
-  
+
   --delete the temp branch
   (discon''''', graph''''') <- evalGraphOp stamp' tempBranchTransId discon'''' graph'''' (DeleteBranch tempBranchName)
   {-
   let rel = runReader (evalRelationalExpr (RelationVariable "s" ())) (mkRelationalExprState $ D.concreteDatabaseContext discon'''')
   traceShowM rel
 -}
-  
+
   pure (discon''''', graph''''')
 
 
@@ -620,7 +626,7 @@ calculateMerkleHash trans graph = hashTransaction trans parentTranses
         Right t -> t
 
 validateMerkleHash :: Transaction -> TransactionGraph -> Either MerkleValidationError ()
-validateMerkleHash trans graph = 
+validateMerkleHash trans graph =
   when (expectedHash /= actualHash) $
     Left (MerkleValidationError (transactionId trans) expectedHash actualHash)
   where
@@ -634,7 +640,7 @@ validateMerkleHashes :: TransactionGraph -> Either [MerkleValidationError] ()
 validateMerkleHashes graph =
   if null errs then pure () else Left errs
   where
-    errs = S.foldr validateTrans [] (transactionsForGraph graph)    
+    errs = S.foldr validateTrans [] (transactionsForGraph graph)
     validateTrans trans acc =
       case validateMerkleHash trans graph of
         Left err -> err : acc

--- a/src/lib/ProjectM36/TransactionGraph/Merge.hs
+++ b/src/lib/ProjectM36/TransactionGraph/Merge.hs
@@ -3,7 +3,12 @@ module ProjectM36.TransactionGraph.Merge where
 import ProjectM36.Base
 import ProjectM36.Error
 import ProjectM36.RelationalExpression
+#if MIN_VERSION_ghc(9,6,0)
+import Control.Monad (foldM)
+import Control.Monad.Except
+#else
 import Control.Monad.Except hiding (join)
+#endif
 import qualified Data.Set as S
 import qualified Data.Map as M
 import qualified ProjectM36.TypeConstructorDef as TCD

--- a/src/lib/ProjectM36/TransactionGraph/Persist.hs
+++ b/src/lib/ProjectM36/TransactionGraph/Persist.hs
@@ -68,11 +68,9 @@ checkForOtherVersions :: FilePath -> IO (Either PersistenceError ())
 checkForOtherVersions dbdir = do
   versionMatches <- globDir1 (compile "m36v*") dbdir
   let otherVersions = L.delete transactionLogFileName (map takeFileName versionMatches)
-  if not (null otherVersions) then
-     pure (Left (WrongDatabaseFormatVersionError transactionLogFileName (head otherVersions)))
-     else
-     pure (Right ())
- 
+  pure $ case otherVersions of
+    [] -> Right ()
+    x : _ -> Left $ WrongDatabaseFormatVersionError transactionLogFileName x
 
 setupDatabaseDir :: DiskSync -> FilePath -> TransactionGraph -> IO (Either PersistenceError (LockFile, LockFileHash))
 setupDatabaseDir sync dbdir bootstrapGraph = do

--- a/src/lib/ProjectM36/TupleSet.hs
+++ b/src/lib/ProjectM36/TupleSet.hs
@@ -21,10 +21,9 @@ verifyTupleSet attrs tupleSet = do
   let tupleList = map (verifyTuple attrs) (asList tupleSet) `P.using` P.parListChunk chunkSize P.r0
       chunkSize = (length . asList) tupleSet `div` 24
   --let tupleList = P.parMap P.rdeepseq (verifyTuple attrs) (HS.toList tupleSet)
-  if not (null (lefts tupleList)) then
-    Left $ head (lefts tupleList)
-   else
-     return $ RelationTupleSet $ (HS.toList . HS.fromList) (rights tupleList)
+  case lefts tupleList of
+    x : _ -> Left x
+    _ -> pure $ RelationTupleSet $ (HS.toList . HS.fromList) (rights tupleList)
 
 mkTupleSet :: Attributes -> [RelationTuple] -> Either RelationalError RelationTupleSet
 mkTupleSet attrs tuples = verifyTupleSet attrs (RelationTupleSet tuples)


### PR DESCRIPTION
This PR adds compatibility support for the modern compiler versions of GHC; i.e. GHC 9.6, GHC 9.8, and GHC 9.10. Given the immense value of the Project-M36 database system, it would be a shame to have it succumb to "bit-rot" at the Haskell ecosystem moves forward. 

Additionally, the PR cleans up compiler warnings emitted by the newer versions of GHC. Most of the warnings were regarding calls to `head` and `tail` generated from `-W-x-partial`.